### PR TITLE
refactor: 인증 로직 및 보안 관련 설정 개선 (#9)

### DIFF
--- a/src/main/java/Bubble/bubblog/domain/post/entity/Tag.java
+++ b/src/main/java/Bubble/bubblog/domain/post/entity/Tag.java
@@ -1,4 +1,4 @@
 package Bubble.bubblog.domain.post.entity;
 
-public class Keyword {
+public class Tag {
 }

--- a/src/main/java/Bubble/bubblog/domain/post/service/BlogPostServiceImpl.java
+++ b/src/main/java/Bubble/bubblog/domain/post/service/BlogPostServiceImpl.java
@@ -73,6 +73,7 @@ public class BlogPostServiceImpl implements BlogPostService {
 
     // 특정 사용자의 게시글 목록 조회
     @Transactional(readOnly = true)
+    @Override
     public List<BlogPostSummaryDTO> getPostsByUser(UUID targetUserId, UUID requesterUserId) {
         boolean isOwner = targetUserId.equals(requesterUserId);
         List<BlogPost> posts;
@@ -87,7 +88,6 @@ public class BlogPostServiceImpl implements BlogPostService {
                 .map(BlogPostSummaryDTO::new)
                 .toList();
     }
-
 
     @Transactional
     @Override

--- a/src/main/java/Bubble/bubblog/domain/user/controller/AuthController.java
+++ b/src/main/java/Bubble/bubblog/domain/user/controller/AuthController.java
@@ -1,52 +1,96 @@
 package Bubble.bubblog.domain.user.controller;
 
+import Bubble.bubblog.domain.user.dto.AccessTokenDTO;
 import Bubble.bubblog.domain.user.dto.LoginRequestDTO;
-import Bubble.bubblog.domain.user.dto.ReissueRequestDTO;
 import Bubble.bubblog.domain.user.dto.SignupRequestDTO;
 import Bubble.bubblog.domain.user.dto.TokensDTO;
 import Bubble.bubblog.domain.user.service.UserService;
 import Bubble.bubblog.global.service.TokenService;
 import Bubble.bubblog.global.util.jwt.JwtUtil;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
+import java.time.Duration;
+import java.util.UUID;
+
+@Tag(name = "User Auth", description = "유저 인증 관련 API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/auth")
+@RequestMapping("/api/auth")
 public class AuthController {
 
     private final UserService userService;
     private final JwtUtil jwtUtil;
     private final TokenService tokenService;
 
+    @Operation(summary = "회원가입")
     @PostMapping("/signup")
     public ResponseEntity<?> signup(@RequestBody SignupRequestDTO request) {
         userService.signup(request);
         return ResponseEntity.ok("회원가입 성공");
     }
 
+    @Operation(summary = "로그인")
     @PostMapping("/login")
-    public ResponseEntity<TokensDTO> login(@RequestBody LoginRequestDTO request) {
+    public ResponseEntity<AccessTokenDTO> login(@RequestBody LoginRequestDTO request) {
         TokensDTO tokens = userService.login(request);
-        return ResponseEntity.ok(tokens);
+
+        ResponseCookie refreshTokenCookie = ResponseCookie.from("refreshToken", tokens.getRefreshToken())
+                .httpOnly(true)
+                .secure(false) // HTTPS 환경에서는 true
+                .path("/")
+                .maxAge(Duration.ofDays(7))
+                .sameSite("Strict")
+                .build();
+        
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString())
+                .body(new AccessTokenDTO(tokens.getAccessToken()));
     }
 
+    @Operation(summary = "로그아웃")
+    @SecurityRequirement(name = "JWT")
     @PostMapping("/logout")
-    public ResponseEntity<?> logout(@AuthenticationPrincipal String userId) {
-        userService.logout(userId);
-        return ResponseEntity.ok("로그아웃 완료");
+    public ResponseEntity<?> logout(@AuthenticationPrincipal UUID userId,
+                                    @CookieValue("refreshToken") String refreshToken) {
+        userService.logout(userId); // Redis에서 삭제
+
+        // 쿠키 제거 (maxAge=0)
+        ResponseCookie deleteCookie = ResponseCookie.from("refreshToken", "")
+                .httpOnly(true)
+                .secure(false)
+                .path("/")
+                .maxAge(0)
+                .sameSite("Strict")
+                .build();
+
+        return ResponseEntity.noContent()
+                .header(HttpHeaders.SET_COOKIE, deleteCookie.toString())
+                .build();
     }
-    
-    // 토큰 재발급
+
+    @Operation(summary = "토큰 재발급")
     @PostMapping("/reissue")
-    public ResponseEntity<TokensDTO> reissue(@RequestBody ReissueRequestDTO request) {
-        TokensDTO newtokens = userService.reissueTokens(request.getRefreshToken());
-        return ResponseEntity.ok(newtokens);
+    public ResponseEntity<AccessTokenDTO> reissue(@CookieValue("refreshToken") String refreshToken) {       // @RequestBody ReissueRequestDTO request
+        TokensDTO newtokens = userService.reissueTokens(refreshToken);
+        ResponseCookie refreshTokenCookie = ResponseCookie.from("refreshToken", newtokens.getRefreshToken())
+                .httpOnly(true)
+                .secure(false)
+                .path("/")
+                .maxAge(Duration.ofDays(7))
+                .sameSite("Strict")
+                .build();
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString())
+                .body(new AccessTokenDTO(newtokens.getAccessToken()));
     }
 
 

--- a/src/main/java/Bubble/bubblog/domain/user/dto/AccessTokenDTO.java
+++ b/src/main/java/Bubble/bubblog/domain/user/dto/AccessTokenDTO.java
@@ -1,0 +1,12 @@
+package Bubble.bubblog.domain.user.dto;
+
+import lombok.Getter;
+
+@Getter
+public class AccessTokenDTO {
+    private String accessToken;
+
+    public AccessTokenDTO(String accessToken) {
+        this.accessToken = accessToken;
+    }
+}

--- a/src/main/java/Bubble/bubblog/global/config/SecurityConfig.java
+++ b/src/main/java/Bubble/bubblog/global/config/SecurityConfig.java
@@ -34,7 +34,9 @@ public class SecurityConfig {
                                 ).permitAll()
                                 // 로그인, 회원가입, 비밀번호 재설정 같은 엔드포인트 허용
                                 .requestMatchers(
-                                        "/auth/**"
+                                        "/api/auth/login",
+                                        "/api/auth/signup",
+                                        "/api/auth/reissue"
                                 ).permitAll()
                         // 그 외 요청은 인증 필요
                         .anyRequest().authenticated()

--- a/src/main/java/Bubble/bubblog/global/service/TokenService.java
+++ b/src/main/java/Bubble/bubblog/global/service/TokenService.java
@@ -1,32 +1,37 @@
 package Bubble.bubblog.global.service;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 @Service
 @RequiredArgsConstructor
 public class TokenService {
 
-    private final RedisTemplate<String, String> redisTemplate;
-    private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000L * 60 * 60 * 24 * 14; // 14일
+    private final StringRedisTemplate redisTemplate;
 
-    public void saveRefreshToken(String userId, String refreshToken) {
+    @Value("${jwt.refresh-expiration}")
+    private long refreshTokenExpireInSeconds;
+
+    public void saveRefreshToken(UUID userId, String refreshToken) {
         redisTemplate.opsForValue().set(
                 "RT:" + userId,
                 refreshToken,
-                REFRESH_TOKEN_EXPIRE_TIME,
-                TimeUnit.MILLISECONDS
+                refreshTokenExpireInSeconds,
+                TimeUnit.SECONDS
         );
     }
 
-    public String getRefreshToken(String userId) {
+    public String getRefreshToken(UUID userId) {
         return redisTemplate.opsForValue().get("RT:" + userId);
     }
 
-    public void deleteRefreshToken(String userId) {
-        redisTemplate.delete("RT:" + userId);
+    public void deleteRefreshToken(UUID userId) {
+        String key = "RT:" + userId;
+        Boolean result = redisTemplate.delete(key);
     }
 }

--- a/src/main/java/Bubble/bubblog/global/util/UuidUtil.java
+++ b/src/main/java/Bubble/bubblog/global/util/UuidUtil.java
@@ -1,9 +1,0 @@
-package Bubble.bubblog.global.util;
-
-import java.util.UUID;
-
-public class UuidUtil {
-    public static UUID generate() {
-        return UUID.randomUUID();
-    }
-}

--- a/src/main/java/Bubble/bubblog/global/util/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/Bubble/bubblog/global/util/jwt/JwtAuthenticationFilter.java
@@ -34,7 +34,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String token = resolveToken(request);
 
         if (token != null && jwtUtil.validateToken(token)) {
-            UUID userId = UUID.fromString(jwtUtil.extractUserId(token));
+            UUID userId = jwtUtil.extractUserId(token);
 
             UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
                     userId, null, List.of(new SimpleGrantedAuthority("ROLE_USER")));

--- a/src/main/java/Bubble/bubblog/global/util/jwt/JwtUtil.java
+++ b/src/main/java/Bubble/bubblog/global/util/jwt/JwtUtil.java
@@ -2,46 +2,69 @@ package Bubble.bubblog.global.util.jwt;
 
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
 import java.util.Date;
+import java.util.UUID;
 
 @Component
 public class JwtUtil {
+    private final Key SECRET_KEY;
 
-    private final String SECRET_KEY = "qwerasdzx/123555/sd7/412/sdfii/d78/2+wdsfsdf+qwe/sdf234/6/this+is+very/secret+key/ilike+hanhwa+ea/gl/es";
-    private final long ACCESS_TOKEN_EXPIRATION = 1000 * 60 * 30; // 30분
-    private final long REFRESH_TOKEN_EXPIRATION = 1000 * 60 * 60 * 24 * 14; // 14일
+    private final long ACCESS_TOKEN_EXPIRATION;
 
-    public String generateAccessToken(String userId) {
+    private final long REFRESH_TOKEN_EXPIRATION;
+
+    public JwtUtil(
+            @Value("${jwt.secret}") String secretKey,
+            @Value("${jwt.access-expiration}") long accessExpiration,
+            @Value("${jwt.refresh-expiration}") long refreshExpiration
+    ) {
+        this.SECRET_KEY = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
+        this.ACCESS_TOKEN_EXPIRATION = accessExpiration;
+        this.REFRESH_TOKEN_EXPIRATION = refreshExpiration;
+    }
+
+    public String generateAccessToken(UUID userId) {
         return Jwts.builder()
-                .setSubject(userId)
-                .setExpiration(new Date(System.currentTimeMillis() + ACCESS_TOKEN_EXPIRATION))
-                .signWith(SignatureAlgorithm.HS512, SECRET_KEY)
+                .setSubject(userId.toString())
+                .setExpiration(new Date(System.currentTimeMillis() + ACCESS_TOKEN_EXPIRATION * 1000))
+                .setId(UUID.randomUUID().toString())
+                .signWith(SECRET_KEY, SignatureAlgorithm.HS512)
                 .compact();
     }
 
-    public String generateRefreshToken(String userId) {
+    public String generateRefreshToken(UUID userId) {
         return Jwts.builder()
-                .setSubject(userId)
-                .setExpiration(new Date(System.currentTimeMillis() + REFRESH_TOKEN_EXPIRATION))
-                .signWith(SignatureAlgorithm.HS512, SECRET_KEY)
+                .setSubject(userId.toString())
+                .setExpiration(new Date(System.currentTimeMillis() + REFRESH_TOKEN_EXPIRATION * 1000))
+                .setId(UUID.randomUUID().toString())
+                .signWith(SECRET_KEY, SignatureAlgorithm.HS512)
                 .compact();
     }
 
     public boolean validateToken(String token) {
         try {
-            Jwts.parser().setSigningKey(SECRET_KEY).parseClaimsJws(token);
+            Jwts.parserBuilder().setSigningKey(SECRET_KEY).build().parseClaimsJws(token);
             return true;
         } catch (Exception e) {
             return false;
         }
     }
 
-    public String extractUserId(String token) {
-        return Jwts.parser()
-                .setSigningKey(SECRET_KEY)
-                .parseClaimsJws(token)
-                .getBody()
-                .getSubject();
+
+    public UUID extractUserId(String token) {
+        String userIdStr = Jwts.parserBuilder()
+                            .setSigningKey(SECRET_KEY)
+                            .build()
+                            .parseClaimsJws(token)
+                            .getBody()
+                            .getSubject();
+
+        return UUID.fromString(userIdStr);
     }
 }


### PR DESCRIPTION
- 파라미터로 전달되는 userId 타입을 UUID로 통일
- 리프레시 토큰을 HttpOnly 쿠키 방식으로 반환하도록 수정
- 민감한 정보 (JWT secret 등)를 환경변수로 관리하도록 변경
- SecurityConfig에서 인증이 필요한 엔드포인트에 permitAll 설정 제거

