### PR TITLE
feat: 유저별 글 조회에 페이지네이션, 카테고리로 필터링 기능 추가

### DIFF
--- a/src/main/java/Bubble/bubblog/domain/category/repository/CategoryClosureRepository.java
+++ b/src/main/java/Bubble/bubblog/domain/category/repository/CategoryClosureRepository.java
@@ -50,4 +50,11 @@ public interface CategoryClosureRepository extends JpaRepository<CategoryClosure
          ORDER BY cc.depth DESC
     """)
     List<String> findAncestorNamesByDescendantId(Long descendantId);
+
+    //자기 자신과 모든 하위 카테고리의 ID를 중복 없이 한 번에 조회한다.
+    @Query("SELECT DISTINCT cc.descendantId " +
+            "FROM CategoryClosure cc " +
+            "WHERE cc.ancestorId = :ancestorId")
+    List<Long> findAllSubtreeIdsIncludingSelf(Long ancestorId);
+
 }

--- a/src/main/java/Bubble/bubblog/domain/post/controller/BlogPostController.java
+++ b/src/main/java/Bubble/bubblog/domain/post/controller/BlogPostController.java
@@ -89,9 +89,19 @@ public class BlogPostController {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @GetMapping("/users/{userId}")
-    public SuccessResponse<UserPostsResponseDTO> getPostsByUser(@PathVariable UUID userId,
-                                                                    @Parameter(hidden = true) @AuthenticationPrincipal UUID requesterId) {
-        UserPostsResponseDTO responseDTO  = blogPostService.getPostsByUser(userId, requesterId);
+    public SuccessResponse<UserPostsResponseDTO> getPostsByUser(
+            @PathVariable UUID userId,
+            @Parameter(hidden = true) @AuthenticationPrincipal UUID requesterId,
+            @RequestParam(required = false) Long categoryId,
+            @ParameterObject
+            @PageableDefault(size = 6, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        UserPostsResponseDTO responseDTO = blogPostService.getPostsByUser(
+                userId,
+                requesterId,
+                categoryId,
+                pageable
+        );
         return SuccessResponse.of(responseDTO);
     }
 

--- a/src/main/java/Bubble/bubblog/domain/post/repository/BlogPostRepository.java
+++ b/src/main/java/Bubble/bubblog/domain/post/repository/BlogPostRepository.java
@@ -5,16 +5,45 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.UUID;
 
 public interface BlogPostRepository extends JpaRepository<BlogPost, Long> {
+    @EntityGraph(attributePaths = {"user"})
     Page<BlogPost> findAllByPublicVisibleTrue(Pageable pageable);
 
     @EntityGraph(attributePaths = {"user"}) // user 정보를 미리 JOIN해서 가져옴
-    List<BlogPost> findAllByUserId(UUID userId);
+    Page<BlogPost> findAllByUserId(UUID userId, Pageable pageable);
 
     @EntityGraph(attributePaths = {"user"}) // 공개 글만 가져오되, user까지 같이
-    List<BlogPost> findAllByUserIdAndPublicVisibleTrue(UUID userId);
+    Page<BlogPost> findAllByUserIdAndPublicVisibleTrue(UUID userId, Pageable pageable);
+
+    @EntityGraph(attributePaths = {"user"})
+    @Query("""
+        SELECT bp
+          FROM BlogPost bp
+         WHERE bp.user.id = :userId
+           AND bp.category.id IN :categoryIds
+    """)
+    Page<BlogPost> findAllByUserIdAndCategory(
+            UUID userId,
+            List<Long> categoryIds,
+            Pageable pageable
+    );
+
+    @EntityGraph(attributePaths = {"user"})
+    @Query("""
+        SELECT bp
+          FROM BlogPost bp
+         WHERE bp.user.id = :userId
+           AND bp.category.id IN :categoryIds
+           AND bp.publicVisible = true
+    """)
+    Page<BlogPost> findAllByUserIdAndCategoryIdInAndPublicVisibleTrue(
+            UUID userId,
+            List<Long> categoryIds,
+            Pageable pageable
+    );
 }

--- a/src/main/java/Bubble/bubblog/domain/post/service/BlogPostService.java
+++ b/src/main/java/Bubble/bubblog/domain/post/service/BlogPostService.java
@@ -13,7 +13,7 @@ public interface BlogPostService {
     BlogPostDetailDTO createPost(BlogPostRequestDTO request, UUID userId);
     BlogPostDetailDTO getPost(Long postId, UUID userId);
     Page<BlogPostSummaryDTO> getAllPosts(Pageable pageable);
-    UserPostsResponseDTO getPostsByUser(UUID targetUserId, UUID requesterUserId);
+    UserPostsResponseDTO getPostsByUser(UUID targetUserId, UUID requesterUserId, Long categoryId, Pageable pageable);
     void deletePost(Long postId, UUID userId);
     BlogPostDetailDTO updatePost(Long postId, BlogPostRequestDTO request, UUID userId);
 }


### PR DESCRIPTION
유저별 글 조회에 페이지네이션 추가
카테고리로 필터링 기능 추가
카테고리가 없으면 유저의 모든 글
하위 카테코리의 글들을 포함해 가져옴

Related to: #37

