### PR TITLE
Fix: 로그아웃 시 Redis에 리프레시 토큰이 삭제되지 않는 버그 해결

### DIFF
--- a/src/main/java/Bubble/bubblog/domain/user/controller/AuthController.java
+++ b/src/main/java/Bubble/bubblog/domain/user/controller/AuthController.java
@@ -15,6 +15,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
@@ -74,6 +75,7 @@ public class AuthController {
         return SuccessResponse.of(new LoginResponseDTO(tokens.getAccessToken(), user.getId()));
     }
 
+    @SecurityRequirement(name = "JWT")
     @Operation(summary = "로그아웃", description = "리프레시 토큰을 쿠키와 Redis에서 삭제하고 로그아웃합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "로그아웃 성공",

--- a/src/main/java/Bubble/bubblog/global/config/SecurityConfig.java
+++ b/src/main/java/Bubble/bubblog/global/config/SecurityConfig.java
@@ -40,7 +40,9 @@ public class SecurityConfig {
                                 ).permitAll()
                                 // 로그인, 회원가입, 비밀번호 재설정 같은 엔드포인트 허용
                                 .requestMatchers(
-                                        "/api/auth/**"
+                                        "/api/auth/login",
+                                        "/api/auth/signup",
+                                        "/api/auth/reissue"
                                 ).permitAll()
                         // 그 외 요청은 인증 필요
                         .anyRequest().authenticated()


### PR DESCRIPTION
Security 설정 파일에서 auth/logout 에 대해 permitAll 설정 제거
permitAll :  Spring Security 인증 필터가 아예 작동하지 않게 만드는 설정이기 때문에 로그아웃 요청 시 userId가 null로 됨

Closes #70 