### PR TITLE
feat: 비공개 게시글에 대한 조회 API 엔드포인트 추가

### DIFF
--- a/src/main/java/Bubble/bubblog/domain/chatbot/controller/PersonaController.java
+++ b/src/main/java/Bubble/bubblog/domain/chatbot/controller/PersonaController.java
@@ -25,12 +25,11 @@ import java.util.UUID;
 @RestController
 @RequestMapping(value = "/api/personas", produces = "application/json")
 @RequiredArgsConstructor
-@SecurityRequirement(name = "JWT")
 public class PersonaController {
 
     private final PersonaService personaService;
 
-    @Operation(summary = "말투 생성", description = "사용자가 챗봇의 말투를 생성합니다.")
+    @Operation(summary = "말투 생성", description = "사용자가 챗봇의 말투를 생성합니다.", security = @SecurityRequirement(name = "JWT"))
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "말투 생성 성공",
                     content = @Content(schema = @Schema(implementation = SuccessResponse.class))),
@@ -54,10 +53,7 @@ public class PersonaController {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @GetMapping("/{personaId}")
-    public SuccessResponse<PersonaResponseDTO> getPersona(
-            @PathVariable Long personaId,
-            @Parameter(hidden = true) @AuthenticationPrincipal UUID userId
-    ) {
+    public SuccessResponse<PersonaResponseDTO> getPersona(@PathVariable Long personaId) {
         PersonaResponseDTO dto = personaService.getPersonaById(personaId);
         return SuccessResponse.of(dto);
     }
@@ -66,14 +62,10 @@ public class PersonaController {
     @Operation(summary = "말투 전체 조회", description = "모든 말투들을 조회합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "말투 목록 조회 성공",
-                    content = @Content(schema = @Schema(implementation = SuccessResponse.class))),
-            @ApiResponse(responseCode = "401", description = "인증 실패",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+                    content = @Content(schema = @Schema(implementation = SuccessResponse.class)))
     })
     @GetMapping
-    public SuccessResponse<List<PersonaResponseDTO>> getAllPersonas(
-            @Parameter(hidden = true) @AuthenticationPrincipal UUID userId
-    ) {
+    public SuccessResponse<List<PersonaResponseDTO>> getAllPersonas() {
         List<PersonaResponseDTO> personas = personaService.getAllPersonas();
         return SuccessResponse.of(personas);
     }
@@ -86,16 +78,14 @@ public class PersonaController {
             @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    @GetMapping("/user/{userId}")
-    public SuccessResponse<List<PersonaResponseDTO>> getPersonasByUserId(
-            @PathVariable UUID userId
-    ) {
+    @GetMapping("/users/{userId}")
+    public SuccessResponse<List<PersonaResponseDTO>> getPersonasByUserId(@PathVariable UUID userId) {
         List<PersonaResponseDTO> personas = personaService.getPersonasByUserId(userId);
         return SuccessResponse.of(personas);
     }
 
 
-    @Operation(summary = "말투 수정", description = "로그인한 사용자가 자신의 말투를 수정합니다.")
+    @Operation(summary = "말투 수정", description = "로그인한 사용자가 자신의 말투를 수정합니다.", security = @SecurityRequirement(name = "JWT"))
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "말투 수정 성공",
                     content = @Content(schema = @Schema(implementation = SuccessResponse.class))),
@@ -116,7 +106,7 @@ public class PersonaController {
         return SuccessResponse.of(updated);
     }
 
-    @Operation(summary = "말투 삭제", description = "로그인한 사용자가 자신의 말투를 삭제합니다.")
+    @Operation(summary = "말투 삭제", description = "로그인한 사용자가 자신의 말투를 삭제합니다.", security = @SecurityRequirement(name = "JWT"))
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "말투 삭제 성공",
                     content = @Content(schema = @Schema(implementation = SuccessResponse.class))),

--- a/src/main/java/Bubble/bubblog/domain/chatbot/service/PersonaServiceImpl.java
+++ b/src/main/java/Bubble/bubblog/domain/chatbot/service/PersonaServiceImpl.java
@@ -66,7 +66,6 @@ public class PersonaServiceImpl implements PersonaService {
                 .toList();
     }
 
-
     // 말투 수정
     @Transactional
     @Override

--- a/src/main/java/Bubble/bubblog/domain/post/repository/PostLikeRepository.java
+++ b/src/main/java/Bubble/bubblog/domain/post/repository/PostLikeRepository.java
@@ -6,21 +6,15 @@ import Bubble.bubblog.domain.user.entity.User;
 import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
+import java.util.UUID;
 
 public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
     Optional<PostLike> findByUserAndPost(User user, BlogPost post);
 
-    @EntityGraph(attributePaths = {"user"})
-    @Query("""
-        SELECT p FROM BlogPost p
-        WHERE p IN (
-            SELECT pl.post FROM PostLike pl WHERE pl.user = :user
-        )
-    """)
-    Page<BlogPost> findLikedPostsByUser(@Param("user") User user, Pageable pageable);
+    @Query("SELECT pl.post FROM PostLike pl WHERE pl.user.id = :userId")  // JPQL
+    Page<BlogPost> findLikedPostsByUser(@Param("userId") UUID userId, Pageable pageable);
 }

--- a/src/main/java/Bubble/bubblog/domain/post/service/BlogPostService.java
+++ b/src/main/java/Bubble/bubblog/domain/post/service/BlogPostService.java
@@ -11,9 +11,10 @@ import java.util.UUID;
 
 public interface BlogPostService {
     BlogPostDetailDTO createPost(BlogPostRequestDTO request, UUID userId);
-    BlogPostDetailDTO getPost(Long postId, UUID userId);
+    BlogPostDetailDTO getPost(Long postId);
     Page<BlogPostSummaryDTO> getAllPosts(String keyword, Pageable pageable);
-    UserPostsResponseDTO getPostsByUser(UUID targetUserId, UUID requesterUserId, Long categoryId, Pageable pageable);
+    UserPostsResponseDTO getPostsByUser(UUID targetUserId, Long categoryId, Pageable pageable);
+    Page<BlogPostSummaryDTO> getLikedPosts(UUID userId, Pageable pageable);
     void deletePost(Long postId, UUID userId);
     BlogPostDetailDTO updatePost(Long postId, BlogPostRequestDTO request, UUID userId);
 

--- a/src/main/java/Bubble/bubblog/domain/user/controller/AuthController.java
+++ b/src/main/java/Bubble/bubblog/domain/user/controller/AuthController.java
@@ -6,7 +6,7 @@ import Bubble.bubblog.domain.user.dto.authRes.TokensDTO;
 import Bubble.bubblog.domain.user.dto.req.LoginRequestDTO;
 import Bubble.bubblog.domain.user.dto.req.SignupRequestDTO;
 import Bubble.bubblog.domain.user.entity.User;
-import Bubble.bubblog.domain.user.service.UserService;
+import Bubble.bubblog.domain.user.service.UserAuthService;
 import Bubble.bubblog.global.dto.ErrorResponse;
 import Bubble.bubblog.global.dto.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -34,7 +34,7 @@ import java.util.UUID;
 @RequestMapping(value = "/api/auth", produces = "application/json")
 public class AuthController {
 
-    private final UserService userService;
+    private final UserAuthService userAuthService;
 
     @Operation(summary = "회원가입", description = "새로운 사용자를 등록합니다.")
     @ApiResponses({
@@ -45,7 +45,7 @@ public class AuthController {
     })
     @PostMapping("/signup")
     public SuccessResponse<Void> signup(@RequestBody SignupRequestDTO request) {
-        userService.signup(request);
+        userAuthService.signup(request);
         return SuccessResponse.of();
     }
 
@@ -58,8 +58,8 @@ public class AuthController {
     })
     @PostMapping("/login")
     public SuccessResponse<LoginResponseDTO> login(@Valid @RequestBody LoginRequestDTO request, HttpServletResponse response) {
-        User user = userService.login(request); // User 객체 반환
-        TokensDTO tokens = userService.issueTokens(user.getId());
+        User user = userAuthService.login(request); // User 객체 반환
+        TokensDTO tokens = userAuthService.issueTokens(user.getId());
 
         ResponseCookie refreshTokenCookie = ResponseCookie.from("refreshToken", tokens.getRefreshToken())
                 .httpOnly(true)
@@ -90,7 +90,7 @@ public class AuthController {
                                     @CookieValue("refreshToken") String refreshToken,
                                     HttpServletResponse response) {
 
-        userService.logout(userId); // Redis에서 삭제
+        userAuthService.logout(userId); // Redis에서 삭제
 
         // 쿠키 제거 (maxAge=0)
         ResponseCookie deleteCookie = ResponseCookie.from("refreshToken", "")
@@ -117,7 +117,7 @@ public class AuthController {
     @PostMapping("/reissue")
     public SuccessResponse<ReissueResponseDTO> reissue(@CookieValue("refreshToken") String refreshToken,
                                                        HttpServletResponse response) {       // @RequestBody ReissueRequestDTO request
-        TokensDTO newtokens = userService.reissueTokens(refreshToken);
+        TokensDTO newtokens = userAuthService.reissueTokens(refreshToken);
         ResponseCookie refreshTokenCookie = ResponseCookie.from("refreshToken", newtokens.getRefreshToken())
                 .httpOnly(true)
                 .secure(true)

--- a/src/main/java/Bubble/bubblog/domain/user/service/UserAuthService.java
+++ b/src/main/java/Bubble/bubblog/domain/user/service/UserAuthService.java
@@ -1,0 +1,17 @@
+package Bubble.bubblog.domain.user.service;
+
+import Bubble.bubblog.domain.user.dto.authRes.TokensDTO;
+import Bubble.bubblog.domain.user.dto.req.LoginRequestDTO;
+import Bubble.bubblog.domain.user.dto.req.SignupRequestDTO;
+import Bubble.bubblog.domain.user.entity.User;
+
+import java.util.UUID;
+
+public interface UserAuthService {
+    // 사용자 인증 서비스
+    void signup(SignupRequestDTO request);
+    User login(LoginRequestDTO request);
+    void logout(UUID userId);
+    TokensDTO reissueTokens(String refreshToken);
+    TokensDTO issueTokens(UUID userId);
+}

--- a/src/main/java/Bubble/bubblog/domain/user/service/UserInfoService.java
+++ b/src/main/java/Bubble/bubblog/domain/user/service/UserInfoService.java
@@ -1,0 +1,17 @@
+package Bubble.bubblog.domain.user.service;
+
+import Bubble.bubblog.domain.post.dto.res.BlogPostDetailDTO;
+import Bubble.bubblog.domain.post.dto.res.UserPostsResponseDTO;
+import Bubble.bubblog.domain.user.dto.infoRes.UserInfoDTO;
+import Bubble.bubblog.domain.user.dto.req.UserUpdateDTO;
+import org.springframework.data.domain.Pageable;
+
+import java.util.UUID;
+
+public interface UserInfoService {
+    // 사용자 정보 서비스
+    UserInfoDTO getUserInfo(UUID userId);
+    void updateUser(UUID userId, UserUpdateDTO request);
+    BlogPostDetailDTO getMyPost(Long postId, UUID userId);
+    UserPostsResponseDTO getMyAllPosts(UUID userId, Long categoryId, Pageable pageable);
+}

--- a/src/main/java/Bubble/bubblog/domain/user/service/UserInfoServiceImpl.java
+++ b/src/main/java/Bubble/bubblog/domain/user/service/UserInfoServiceImpl.java
@@ -1,0 +1,115 @@
+package Bubble.bubblog.domain.user.service;
+
+import Bubble.bubblog.domain.category.repository.CategoryClosureRepository;
+import Bubble.bubblog.domain.category.repository.CategoryRepository;
+import Bubble.bubblog.domain.post.dto.res.BlogPostDetailDTO;
+import Bubble.bubblog.domain.post.dto.res.BlogPostSummaryDTO;
+import Bubble.bubblog.domain.post.dto.res.UserPostsResponseDTO;
+import Bubble.bubblog.domain.post.entity.BlogPost;
+import Bubble.bubblog.domain.post.repository.BlogPostRepository;
+import Bubble.bubblog.domain.post.repository.PostLikeRepository;
+import Bubble.bubblog.domain.user.dto.infoRes.UserInfoDTO;
+import Bubble.bubblog.domain.user.dto.req.UserUpdateDTO;
+import Bubble.bubblog.domain.user.entity.User;
+import Bubble.bubblog.domain.user.repository.UserRepository;
+import Bubble.bubblog.global.exception.CustomException;
+import Bubble.bubblog.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class UserInfoServiceImpl implements UserInfoService {
+
+    private final UserRepository userRepository;
+    private final BlogPostRepository blogPostRepository;
+    private final CategoryClosureRepository categoryClosureRepository;
+    private final CategoryRepository categoryRepository;
+    private final PostLikeRepository postLikeRepository;
+
+    // user 정보 조회
+    @Override
+    @Transactional(readOnly = true)
+    public UserInfoDTO getUserInfo(UUID userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        return new UserInfoDTO(
+                user.getId(),
+                user.getNickname(),
+                user.getProfileImageUrl()
+        );
+    }
+
+    // user 정보 수정
+    @Override
+    @Transactional
+    public void updateUser(UUID userId, UserUpdateDTO request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        // 닉네임 수정
+        String newNickname = request.getNickname();
+        if (newNickname != null && !newNickname.equals(user.getNickname())) {
+            if (userRepository.existsByNickname(newNickname)) {
+                throw new CustomException(ErrorCode.DUPLICATE_NICKNAME);
+            }
+            user.updateNickname(newNickname);
+        }
+
+        // 프로필 이미지 수정 (null이면 이미지 제거)
+        user.updateProfileImageUrl(request.getProfileImageUrl());
+    }
+
+    // 나의 게시글 상세 조회 (공개 및 비공개 포함)
+    @Override
+    @Transactional(readOnly = true)
+    public BlogPostDetailDTO getMyPost(Long postId, UUID userId) {
+       BlogPost post = blogPostRepository.findById(postId)
+                .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
+
+        // 로그인한 사용자가 게시글의 소유자인지 확인
+        boolean isOwner = post.getUser().getId().equals(userId);
+
+        if (!isOwner) {
+            // 로그인했지만, 자신의 게시글이 아니라면 접근 거부 (비공개든 공개든 상관없이)
+            throw new CustomException(ErrorCode.UNAUTHORIZED_POST_ACCESS);
+        }
+
+        // 소유자라면 공개/비공개 여부와 상관없이 접근 허용
+        List<String> categoryList = categoryClosureRepository.findAncestorNamesByDescendantId(post.getCategory().getId());
+        return new BlogPostDetailDTO(post, categoryList);
+    }
+
+    // 나의 게시글 목록 조회 (공개 및 비공개 포함)
+    @Override
+    @Transactional(readOnly = true)
+    public UserPostsResponseDTO getMyAllPosts(UUID userId, Long categoryId, Pageable pageable) {
+        List<Long> categoryIds = null;
+        if (categoryId != null) {
+            if (!categoryRepository.existsById(categoryId)) {
+                throw new CustomException(ErrorCode.CATEGORY_NOT_FOUND);
+            }
+            categoryIds = categoryClosureRepository.findAllSubtreeIdsIncludingSelf(categoryId);
+        }
+
+        Page<BlogPost> posts = blogPostRepository
+                .searchUserPosts(userId, true, categoryIds, pageable);   // isOwner을 false로 고정 -> 공개 게시글만 조회하니까
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        return new UserPostsResponseDTO(
+                user.getId(),
+                user.getNickname(),
+                posts.map(BlogPostSummaryDTO::new).getContent()
+        );
+    }
+
+}

--- a/src/main/java/Bubble/bubblog/global/config/SecurityConfig.java
+++ b/src/main/java/Bubble/bubblog/global/config/SecurityConfig.java
@@ -6,6 +6,7 @@ import Bubble.bubblog.global.util.jwt.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -39,14 +40,17 @@ public class SecurityConfig {
                                         "/api/v3/api-docs.yaml"
                                 ).permitAll()
                                 // 로그인, 회원가입, 비밀번호 재설정 같은 엔드포인트 허용
-                                .requestMatchers(
-                                        "/api/auth/login",
-                                        "/api/auth/signup",
-                                        "/api/auth/reissue"
-                                ).permitAll()
+                                .requestMatchers("/api/auth/login", "/api/auth/signup", "/api/auth/reissue").permitAll()
+                                // 게시글 조회 관련 API 허용
+                                .requestMatchers(HttpMethod.GET, "/api/posts/**").permitAll()
+                                // 조회수 증가 API 허용
+                                .requestMatchers(HttpMethod.PUT, "/api/posts/*/view").permitAll()
+                                // 말투 조회 관련 API 허용
+                                .requestMatchers(HttpMethod.GET, "/api/personas/**").permitAll()
+                                // 사용자 정보 조회 관련 API 허용
+                                .requestMatchers(HttpMethod.GET, "/api/users/{userId}").permitAll()
                         // 그 외 요청은 인증 필요
                         .anyRequest().authenticated()
-
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .exceptionHandling(ex -> ex
@@ -58,6 +62,6 @@ public class SecurityConfig {
 
     @Bean
     public PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder(); // ✅ 여기다 넣어도 OK
+        return new BCryptPasswordEncoder();
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,3 +13,10 @@ springdoc:
     path: /api/v3/api-docs
   swagger-ui:
     path: /api/swagger-ui.html
+
+logging:
+  level:
+    root: DEBUG
+    org.springframework: DEBUG
+    org.hibernate.SQL: DEBUG
+


### PR DESCRIPTION
### 추가된 사항 요약
비공개 게시글에 대한 조회 API 엔드포인트 추가 / 비인가 접근 허용을 위한 Security 설정 수정 / 인터페이스 분리 원칙에 따른 유저 도메인의 Auth와 Info 기능 인터페이스 분리

- **추가된 엔드포인트**
    비공개 게시글(공개 게시글 포함)에 대한 조회를 위한 API
    - /api/me/posts/{postId} : 나의 게시글 상세 조회, 비공개 게시글에도 접근 가능, 로그인 시에만 접근 허용
    - /api/me/posts : 나의 게시글 목록 조회, 비공개 게시글까지 조회 가능, 로그인 시에만 접근 허용

 - **기존 내용에서 수정된 부분**
     - 게시글 관련 엔드포인트 경로 수정 : 기존(/api/blogs) -> 변경(/api/posts)
     - User도메인의 auth와 info 기능별 service 인터페이스 분리
     - @AuthenticationPrincipal을 통해 유효성이 이미 검증된 userId에 대해, 불필요한 userRepository.findById(userId) 조회를 제거
     - Security 설정 (permitAll() 적용)
       1. `HttpMethod.GET` 요청에 대해 `/api/blogs/**`, `/api/personas/**`, `/api/users/{userId}` 경로에 `permitAll()`을 설정하여 (공개)게시글/페르소나/사용자 정보 조회 API를 로그인 없이 접근 가능하도록 허용
       2. `/api/blogs/*/view`에 대한 `HttpMethod.PUT` 요청(조회수 증가 API)도 `permitAll()`을 설정하여 조회수 증가 기능을 공개적으로 허용