### PR TITLE
Feat/tag : 태그 기능 추가

### DIFF
--- a/src/main/java/Bubble/bubblog/domain/chatbot/controller/PersonaController.java
+++ b/src/main/java/Bubble/bubblog/domain/chatbot/controller/PersonaController.java
@@ -25,12 +25,11 @@ import java.util.UUID;
 @RestController
 @RequestMapping(value = "/api/personas", produces = "application/json")
 @RequiredArgsConstructor
-@SecurityRequirement(name = "JWT")
 public class PersonaController {
 
     private final PersonaService personaService;
 
-    @Operation(summary = "말투 생성", description = "사용자가 챗봇의 말투를 생성합니다.")
+    @Operation(summary = "말투 생성", description = "사용자가 챗봇의 말투를 생성합니다.", security = @SecurityRequirement(name = "JWT"))
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "말투 생성 성공",
                     content = @Content(schema = @Schema(implementation = SuccessResponse.class))),
@@ -54,10 +53,7 @@ public class PersonaController {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @GetMapping("/{personaId}")
-    public SuccessResponse<PersonaResponseDTO> getPersona(
-            @PathVariable Long personaId,
-            @Parameter(hidden = true) @AuthenticationPrincipal UUID userId
-    ) {
+    public SuccessResponse<PersonaResponseDTO> getPersona(@PathVariable Long personaId) {
         PersonaResponseDTO dto = personaService.getPersonaById(personaId);
         return SuccessResponse.of(dto);
     }
@@ -66,14 +62,10 @@ public class PersonaController {
     @Operation(summary = "말투 전체 조회", description = "모든 말투들을 조회합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "말투 목록 조회 성공",
-                    content = @Content(schema = @Schema(implementation = SuccessResponse.class))),
-            @ApiResponse(responseCode = "401", description = "인증 실패",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+                    content = @Content(schema = @Schema(implementation = SuccessResponse.class)))
     })
     @GetMapping
-    public SuccessResponse<List<PersonaResponseDTO>> getAllPersonas(
-            @Parameter(hidden = true) @AuthenticationPrincipal UUID userId
-    ) {
+    public SuccessResponse<List<PersonaResponseDTO>> getAllPersonas() {
         List<PersonaResponseDTO> personas = personaService.getAllPersonas();
         return SuccessResponse.of(personas);
     }
@@ -86,16 +78,14 @@ public class PersonaController {
             @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    @GetMapping("/user/{userId}")
-    public SuccessResponse<List<PersonaResponseDTO>> getPersonasByUserId(
-            @PathVariable UUID userId
-    ) {
+    @GetMapping("/users/{userId}")
+    public SuccessResponse<List<PersonaResponseDTO>> getPersonasByUserId(@PathVariable UUID userId) {
         List<PersonaResponseDTO> personas = personaService.getPersonasByUserId(userId);
         return SuccessResponse.of(personas);
     }
 
 
-    @Operation(summary = "말투 수정", description = "로그인한 사용자가 자신의 말투를 수정합니다.")
+    @Operation(summary = "말투 수정", description = "로그인한 사용자가 자신의 말투를 수정합니다.", security = @SecurityRequirement(name = "JWT"))
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "말투 수정 성공",
                     content = @Content(schema = @Schema(implementation = SuccessResponse.class))),
@@ -116,7 +106,7 @@ public class PersonaController {
         return SuccessResponse.of(updated);
     }
 
-    @Operation(summary = "말투 삭제", description = "로그인한 사용자가 자신의 말투를 삭제합니다.")
+    @Operation(summary = "말투 삭제", description = "로그인한 사용자가 자신의 말투를 삭제합니다.", security = @SecurityRequirement(name = "JWT"))
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "말투 삭제 성공",
                     content = @Content(schema = @Schema(implementation = SuccessResponse.class))),

--- a/src/main/java/Bubble/bubblog/domain/chatbot/service/PersonaServiceImpl.java
+++ b/src/main/java/Bubble/bubblog/domain/chatbot/service/PersonaServiceImpl.java
@@ -66,7 +66,6 @@ public class PersonaServiceImpl implements PersonaService {
                 .toList();
     }
 
-
     // 말투 수정
     @Transactional
     @Override

--- a/src/main/java/Bubble/bubblog/domain/comment/controller/CommentController.java
+++ b/src/main/java/Bubble/bubblog/domain/comment/controller/CommentController.java
@@ -1,0 +1,105 @@
+package Bubble.bubblog.domain.comment.controller;
+
+import Bubble.bubblog.domain.comment.dto.req.UpdateCommentDTO;
+import Bubble.bubblog.domain.comment.dto.res.CommentResponseDTO;
+import Bubble.bubblog.domain.comment.dto.res.CommentThreadResponseDTO;
+import Bubble.bubblog.domain.comment.service.commentservice.CommentService;
+import Bubble.bubblog.global.dto.ErrorResponse;
+import Bubble.bubblog.global.dto.SuccessResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor   // DI를 위함
+@RequestMapping(value = "/api/comments", produces = "application/json")
+@Tag(name = "Comment", description = "게시글 댓글 관련 API")   // 스웨거 전용
+public class CommentController {
+    private final CommentService commentService;
+
+
+    /** 특정 댓글 단건 조회 */
+    @Operation(summary = "댓글 단건 상세 조회", description = "특정 commentId의 단건 상세를 조회합니다")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(schema = @Schema(implementation = SuccessResponse.class))),
+            @ApiResponse(responseCode = "404", description = "댓글을 찾을 수 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @GetMapping("/{commentId}")
+    public SuccessResponse<CommentResponseDTO> getCommentDetail(@PathVariable Long commentId) {
+        CommentResponseDTO dto = commentService.getCommentDetail(commentId);
+        return SuccessResponse.of(dto);
+    }
+
+    /** 특정 루트 댓글의 자식 댓글 목록을 페이징으로 조회 */
+    @Operation(summary = "루트 댓글의 자식들 페이징 조회", description = "특정 루트 댓글의 자식들을 페이징 처리하여 반환합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(schema = @Schema(implementation = SuccessResponse.class))),
+            @ApiResponse(responseCode = "404", description = "해당 루트 댓글을 찾을 수 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @GetMapping("/{commentId}/children")
+    public SuccessResponse<Page<CommentResponseDTO>> getChildrenByRoot(@PathVariable Long commentId, @ParameterObject @PageableDefault(size = 10, sort = "createdAt") Pageable pageable) {
+        Page<CommentResponseDTO> dto = commentService.getChildrenByRoot(commentId, pageable);
+        return SuccessResponse.of(dto);
+    }
+
+
+    /** 특정 루트 댓글과 그 모든 자식 댓글 함께 조회 (스레드 조회) */
+    @Operation(summary = "루트 댓글과 모든 자식들을 함께 스레드로 조회", description = "루트 댓글 하나와 그 자식(대댓글)들을 함께 반환합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(schema = @Schema(implementation = SuccessResponse.class))),
+            @ApiResponse(responseCode = "404", description = "해당 루트 댓글을 찾을 수 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @GetMapping("/{commentId}/thread")
+    public SuccessResponse<CommentThreadResponseDTO> getThreadByRoot(@PathVariable Long commentId) {
+        CommentThreadResponseDTO dto = commentService.getThreadByRoot(commentId);
+        return SuccessResponse.of(dto);
+    }
+
+
+    /** 댓글 수정 */
+    @Operation(summary = "댓글 수정", description = "본인이 작성한 댓글만 수정할 수 있습니다.", security = @SecurityRequirement(name = "JWT"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "수정 성공", content = @Content(schema = @Schema(implementation = SuccessResponse.class))),
+            @ApiResponse(responseCode = "400", description = "입력값이 유효하지 않음", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "수정 권한 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "댓글을 찾을 수 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @PutMapping("/{commentId}")
+    public SuccessResponse<CommentResponseDTO> updateComment(@PathVariable Long commentId, @Valid @RequestBody UpdateCommentDTO request,
+                                                            @Parameter(hidden = true) @AuthenticationPrincipal UUID userId
+    ) {
+        String newContent = request.getContent();
+        CommentResponseDTO dto = commentService.updateComment(commentId, userId, newContent);
+        return SuccessResponse.of(dto);
+    }
+
+
+    /** 댓글 삭제 */
+    @Operation(summary = "댓글 삭제", description = "본인이 작성한 댓글만 삭제(Soft delete)할 수 있습니다.", security = @SecurityRequirement(name = "JWT"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "삭제 성공", content = @Content(schema = @Schema(implementation = SuccessResponse.class))),
+            @ApiResponse(responseCode = "403", description = "삭제 권한 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "댓글을 찾을 수 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @DeleteMapping("/{commentId}")
+    public SuccessResponse<Void> deleteComment(@PathVariable Long commentId, @Parameter(hidden = true) @AuthenticationPrincipal UUID userId) {
+        commentService.deleteComment(commentId, userId);
+        return SuccessResponse.of();
+    }
+
+}

--- a/src/main/java/Bubble/bubblog/domain/comment/controller/CommentLikeController.java
+++ b/src/main/java/Bubble/bubblog/domain/comment/controller/CommentLikeController.java
@@ -1,0 +1,41 @@
+package Bubble.bubblog.domain.comment.controller;
+
+import Bubble.bubblog.domain.comment.service.commentlikeservice.CommentLikeService;
+import Bubble.bubblog.global.dto.SuccessResponse;
+import Bubble.bubblog.global.dto.ErrorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io. swagger. v3.oas. annotations.Parameter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping(value = "/api/comments/{commentId}/likes", produces = "application/json")
+@Tag(name = "CommentLike", description = "댓글 좋아요 관련 API")
+public class CommentLikeController {
+    private final CommentLikeService commentLikeService;
+    
+    
+    /** 댓글 좋아요/취소 */
+    @Operation(summary = "댓글 좋아요/좋아요 취소", description = "댓글 좋아요를 토글합니다.", security = @SecurityRequirement(name = "JWT"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "댓글 좋아요 성공", content = @Content(schema = @Schema(implementation = SuccessResponse.class))),
+            @ApiResponse(responseCode = "404", description = "댓글을 찾을 수 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @PostMapping
+    public SuccessResponse<Void> toggleCommentLike(@PathVariable Long commentId, @Parameter(hidden = true) @AuthenticationPrincipal UUID userId) {
+        commentLikeService.toggleCommentLike(commentId, userId);
+        return SuccessResponse.of();
+    }
+}

--- a/src/main/java/Bubble/bubblog/domain/comment/dto/CommentMapper.java
+++ b/src/main/java/Bubble/bubblog/domain/comment/dto/CommentMapper.java
@@ -1,0 +1,54 @@
+package Bubble.bubblog.domain.comment.dto;
+
+import Bubble.bubblog.domain.comment.dto.res.CommentThreadResponseDTO;
+import Bubble.bubblog.domain.comment.dto.res.CommentResponseDTO;
+import Bubble.bubblog.domain.comment.entity.Comment;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class CommentMapper {
+    private static final String DELETED_PLACEHOLDER = "삭제된 댓글입니다.";
+
+    /** 단일 댓글 */
+    private CommentResponseDTO toDto(Comment comment, Long replyCount) {
+        Long parentId = (comment.getParent() == null) ? null : comment.getParent().getId();
+
+        return CommentResponseDTO.builder()
+                .id(comment.getId())
+                .content(comment.getIsDeleted() ? DELETED_PLACEHOLDER : comment.getContent())
+                .deleted(comment.getIsDeleted())
+                .writerNickname(comment.getUser().getNickname())
+                .writerProfileImage(comment.getUser().getProfileImageUrl())
+                .likeCount(comment.getLikeCount())
+                .createdAt(comment.getCreatedAt())
+                .updatedAt(comment.getUpdatedAt())
+                .parentId(parentId)
+                .replyCount(replyCount)   // 기존 children.size() 방식에서 집계 값을 인자로 받는 것으로 리팩토링 => N+1문제 개선
+                .build();
+    }
+
+    /** 루트 항목 : replyCount 집계값으로 주입 */
+    public CommentResponseDTO toRoot(Comment root, long replyCount) {
+        return toDto(root, replyCount);
+    }
+
+    /** 자식 항목 : replyCount를 null로 */
+    public CommentResponseDTO toChild(Comment child) {
+        return toDto(child, null);
+    }
+
+
+    /** 스레드 래퍼 : 계층 구조 응답 */
+    public CommentThreadResponseDTO toThread(Comment root, long replyCount, List<Comment> children) {
+        CommentResponseDTO rootDto = toRoot(root, replyCount);
+        List<CommentResponseDTO> childrenDto = children.stream().map(this::toChild).toList();
+
+        return CommentThreadResponseDTO.builder()
+                .root(rootDto)
+                .children(childrenDto)
+                .build();
+    }
+
+}

--- a/src/main/java/Bubble/bubblog/domain/comment/dto/ReplyCount.java
+++ b/src/main/java/Bubble/bubblog/domain/comment/dto/ReplyCount.java
@@ -1,0 +1,7 @@
+package Bubble.bubblog.domain.comment.dto;
+
+/** replyCount 집계용 Projection */
+public interface ReplyCount {
+    Long getRootId();
+    Long getCnt();
+}

--- a/src/main/java/Bubble/bubblog/domain/comment/dto/req/CreateCommentDTO.java
+++ b/src/main/java/Bubble/bubblog/domain/comment/dto/req/CreateCommentDTO.java
@@ -1,0 +1,19 @@
+package Bubble.bubblog.domain.comment.dto.req;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor   // 기본 생성자는 Jackson 역직렬화를 위해
+public class CreateCommentDTO {
+    @NotBlank(message = "댓글은 필수입니다")
+    @Size(min = 1, max = 1000, message = "댓글은 최대 1000자까지 가능합니다")
+    @Schema(description = "댓글 내용", example = "오늘 경기 너무 재밌었어요!")
+    private String content;
+
+    @Schema(description = "부모 ID", example = "null 또는 ID")
+    private Long parentId; // 대댓글용 (null이면 최상위 댓글)
+}

--- a/src/main/java/Bubble/bubblog/domain/comment/dto/req/UpdateCommentDTO.java
+++ b/src/main/java/Bubble/bubblog/domain/comment/dto/req/UpdateCommentDTO.java
@@ -1,0 +1,16 @@
+package Bubble.bubblog.domain.comment.dto.req;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UpdateCommentDTO {
+    @NotBlank(message = "댓글은 필수입니다")
+    @Size(min = 1, max = 1000, message = "댓글은 최대 1000자까지 가능합니다")
+    @Schema(description = "댓글 내용", example = "댓글 수정했어요!")
+    private String content;
+}

--- a/src/main/java/Bubble/bubblog/domain/comment/dto/res/CommentResponseDTO.java
+++ b/src/main/java/Bubble/bubblog/domain/comment/dto/res/CommentResponseDTO.java
@@ -1,0 +1,33 @@
+package Bubble.bubblog.domain.comment.dto.res;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class CommentResponseDTO {
+    private Long id;
+
+    private String content;
+
+    private boolean deleted;
+
+    private String writerNickname;
+
+    private String writerProfileImage;
+
+    private Integer likeCount;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+    private Long parentId;   // 루트 : null, 자식 : parentId
+
+    private Long replyCount;  // 자식은 null
+
+}

--- a/src/main/java/Bubble/bubblog/domain/comment/dto/res/CommentThreadResponseDTO.java
+++ b/src/main/java/Bubble/bubblog/domain/comment/dto/res/CommentThreadResponseDTO.java
@@ -1,0 +1,15 @@
+package Bubble.bubblog.domain.comment.dto.res;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class CommentThreadResponseDTO {
+    private CommentResponseDTO root;
+    private List<CommentResponseDTO> children;
+}

--- a/src/main/java/Bubble/bubblog/domain/comment/entity/Comment.java
+++ b/src/main/java/Bubble/bubblog/domain/comment/entity/Comment.java
@@ -1,0 +1,110 @@
+package Bubble.bubblog.domain.comment.entity;
+
+import Bubble.bubblog.domain.post.entity.BlogPost;
+import Bubble.bubblog.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "comment")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+// @SQLDelete(sql="UPDATE comment SET is_deleted = true, deleted_at = NOW() WHERE id = ?")  // repository.delete()를 호출해도 soft하게 삭제 될 수 있게 보장. 현재는 클래스에 softDelete가 내부 메서드로 있기 때문에 굳이 없어도 됨.
+public class Comment {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "content", nullable = false, length = 1000)
+    private String content;
+
+    // Many to one은 기본은 Eager 전략 -> Lazy로 설정해서 불필요한 Join을 막음
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private BlogPost post;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    // 대댓글 구조를 위한 자기 참조
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_id")
+    private Comment parent;
+
+    @OneToMany(mappedBy = "parent", cascade = CascadeType.PERSIST, fetch = FetchType.LAZY)
+    private List<Comment> children = new ArrayList<>();
+
+    @Column(name = "like_count", nullable = false)
+    private Integer likeCount = 0;
+
+    @Column(name = "is_deleted", nullable = false)
+    private Boolean isDeleted = false;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    // 객체 생성 메서드 (팩토리 메서드)
+    public static Comment createComment(String content, BlogPost post, User user) {
+        Comment comment = new Comment();
+        comment.content = content;
+        comment.post = post;
+        comment.user = user;
+        comment.parent = null; // 최상위 댓글
+        return comment;
+    }
+
+    // 대댓글 생성 메서드
+    public static Comment createReply(String newContent, BlogPost post, User user, Comment parent) {
+        Comment comment = new Comment();
+        comment.content = newContent;
+        comment.post = post;
+        comment.user = user;
+        comment.parent = parent;
+
+        parent.children.add(comment);
+        return comment;
+    }
+
+    public void softDelete() {
+        this.isDeleted = true;
+        this.deletedAt = LocalDateTime.now();
+    }
+
+    public void updateContent(String newContent) {
+        this.content = newContent;
+    }
+
+    public void incrementLikeCount() {
+        this.likeCount++;
+    }
+
+    public void decrementLikeCount() {
+        if (this.likeCount > 0) {
+            this.likeCount--;
+        }
+    }
+
+    // 복원 메서드 (관리자용)
+    public void restore() {
+        this.isDeleted = false;
+        this.deletedAt = null;
+    }
+
+}

--- a/src/main/java/Bubble/bubblog/domain/comment/entity/CommentLike.java
+++ b/src/main/java/Bubble/bubblog/domain/comment/entity/CommentLike.java
@@ -1,0 +1,41 @@
+package Bubble.bubblog.domain.comment.entity;
+
+import Bubble.bubblog.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "comment_like", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"comment_id", "user_id"})
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CommentLike {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "comment_id", nullable = false)
+    private Comment comment;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    public static CommentLike createCommentLike(Comment comment, User user) {
+        CommentLike commentLike = new CommentLike();
+        commentLike.comment = comment;
+        commentLike.user = user;
+        return commentLike;
+    }
+}

--- a/src/main/java/Bubble/bubblog/domain/comment/repository/CommentLikeRepository.java
+++ b/src/main/java/Bubble/bubblog/domain/comment/repository/CommentLikeRepository.java
@@ -1,0 +1,12 @@
+package Bubble.bubblog.domain.comment.repository;
+
+import Bubble.bubblog.domain.comment.entity.Comment;
+import Bubble.bubblog.domain.comment.entity.CommentLike;
+import Bubble.bubblog.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface CommentLikeRepository extends JpaRepository<CommentLike, Long> {
+    Optional<CommentLike> findByCommentAndUser(Comment comment, User user);
+}

--- a/src/main/java/Bubble/bubblog/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/Bubble/bubblog/domain/comment/repository/CommentRepository.java
@@ -1,0 +1,90 @@
+package Bubble.bubblog.domain.comment.repository;
+
+import Bubble.bubblog.domain.comment.dto.ReplyCount;
+import Bubble.bubblog.domain.comment.entity.Comment;
+import Bubble.bubblog.domain.post.entity.BlogPost;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    // User와 같이 fetch join해서 댓글 단건을 불러옴.
+    @Query("""
+        SELECT c
+        FROM Comment c
+        JOIN FETCH c.user
+        WHERE c.id = :id
+    """)
+    Optional<Comment> findByIdWithUser(@Param("id") Long id);
+
+    // replyCount 집계 쿼리 : 루트ID 묶음에 대한 자식 개수 -> 별도의 집계 쿼리를 구성하지 않으면 루트 개수만큼 쿼리를 날림(각 루트마다 children에 접근하므로)
+    @Query("""
+         SELECT c.parent.id AS rootId, COUNT(c.id) AS cnt
+         FROM Comment c
+         WHERE c.parent.id IN :rootIds
+         GROUP BY c.parent.id
+    """)
+    List<ReplyCount> countByParentIds(@Param("rootIds") Collection<Long> rootIds);
+
+    // 루트 목록 조회 : N+1문제 방지를 위해 root 조회 시 user까지 한방에 조회
+    @Query("""
+        SELECT c FROM Comment c
+        JOIN FETCH c.user
+        WHERE c.post.id = :postId
+          AND c.parent IS NULL
+        ORDER BY c.createdAt ASC
+    """)
+    List<Comment> findRootCommentsByPostId(@Param("postId") Long postId);
+
+    // 스레드를 위해서 조회 : 특정 루트의 자식들 및 user를 한방에 가져옴
+    @Query("""
+        SELECT c FROM Comment c
+        JOIN FETCH c.user
+        WHERE c.parent.id = :rootId
+        ORDER BY c.createdAt ASC
+    """)
+    List<Comment> findChildrenByRootIdForThread(@Param("rootId") Long rootId);
+
+    // 인자로 받은 id가 부모 id인, 즉 그 자식들 수 카운트
+    Long countByParentId(Long commentId);
+
+    // 특정 루트 댓글의 자식들을 페이징하여 조회 및 user를 한방에 가져옴
+    @Query(value = """
+        SELECT c FROM Comment c
+        JOIN FETCH c.user
+        WHERE c.parent.id = :rootId
+        ORDER BY c.createdAt ASC
+    """, countQuery = "SELECT COUNT(c) FROM Comment c WHERE c.parent.id = :rootId")
+    Page<Comment> findChildrenByParentId(@Param("rootId") Long rootId, Pageable pageable);
+
+    @Query("select count(c) from Comment c where c.post.id = :postId")
+    Long countByPostId(@Param("postId") Long postId);
+
+    // 내가 작성한 댓글들 목록 조회
+    @Query(value = """
+        SELECT c FROM Comment c
+        JOIN FETCH c.user
+        WHERE c.user.id = :userId AND c.isDeleted = false
+        ORDER BY c.createdAt DESC
+    """, countQuery = "SELECT COUNT(c) FROM Comment c WHERE c.user.id = :userId AND c.isDeleted = false")
+    Page<Comment> findByUserId(UUID userId, Pageable pageable);
+
+    // 내가 댓글 단 게시글 목록 중복 없이 가져오기 + is_deleted = false 조건을 추가하여 삭제된 댓글을 조회에서 제외
+    @Query(value = """
+        SELECT DISTINCT c.post FROM Comment c
+        JOIN FETCH c.post.user
+        WHERE c.user.id = :userId AND c.isDeleted = false
+        ORDER BY c.post.createdAt DESC
+    """, countQuery = "SELECT COUNT(DISTINCT c.post.id) FROM Comment c WHERE c.user.id = :userId AND c.isDeleted = false")
+    Page<BlogPost> findCommentedPostsByUserId(UUID userId, Pageable pageable);
+}

--- a/src/main/java/Bubble/bubblog/domain/comment/service/commentlikeservice/CommentLikeService.java
+++ b/src/main/java/Bubble/bubblog/domain/comment/service/commentlikeservice/CommentLikeService.java
@@ -1,0 +1,7 @@
+package Bubble.bubblog.domain.comment.service.commentlikeservice;
+
+import java.util.UUID;
+
+public interface CommentLikeService {
+    void toggleCommentLike(Long commentId, UUID userId);
+}

--- a/src/main/java/Bubble/bubblog/domain/comment/service/commentlikeservice/CommentLikeServiceImpl.java
+++ b/src/main/java/Bubble/bubblog/domain/comment/service/commentlikeservice/CommentLikeServiceImpl.java
@@ -1,0 +1,52 @@
+package Bubble.bubblog.domain.comment.service.commentlikeservice;
+
+import Bubble.bubblog.domain.comment.entity.Comment;
+import Bubble.bubblog.domain.comment.entity.CommentLike;
+import Bubble.bubblog.domain.comment.repository.CommentLikeRepository;
+import Bubble.bubblog.domain.comment.repository.CommentRepository;
+import Bubble.bubblog.domain.user.entity.User;
+import Bubble.bubblog.domain.user.repository.UserRepository;
+import Bubble.bubblog.global.exception.CustomException;
+import Bubble.bubblog.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class CommentLikeServiceImpl implements CommentLikeService {
+    private final CommentRepository commentRepository;
+    private final CommentLikeRepository commentLikeRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    @Override
+    public void toggleCommentLike(Long commentId, UUID userId) {
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new CustomException(ErrorCode.COMMENT_NOT_FOUND));
+
+        if (comment.getIsDeleted()) {
+            throw new CustomException(ErrorCode.CANNOT_LIKE_DELETED_COMMENT);
+        }
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        commentLikeRepository.findByCommentAndUser(comment, user)
+                .ifPresentOrElse(
+                        // 이미 좋아요를 누른 경우
+                        commentLike -> {
+                            commentLikeRepository.delete(commentLike);
+                            comment.decrementLikeCount();
+                        },
+                        // 좋아요를 누르지 않은 경우
+                        () -> {
+                            CommentLike newLike = CommentLike.createCommentLike(comment, user);
+                            commentLikeRepository.save(newLike);
+                            comment.incrementLikeCount();
+                        }
+                );
+    }
+}

--- a/src/main/java/Bubble/bubblog/domain/comment/service/commentservice/CommentService.java
+++ b/src/main/java/Bubble/bubblog/domain/comment/service/commentservice/CommentService.java
@@ -1,0 +1,23 @@
+package Bubble.bubblog.domain.comment.service.commentservice;
+
+import Bubble.bubblog.domain.comment.dto.req.CreateCommentDTO;
+import Bubble.bubblog.domain.comment.dto.res.CommentResponseDTO;
+import Bubble.bubblog.domain.comment.dto.res.CommentThreadResponseDTO;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface CommentService {
+    CommentResponseDTO createComment(CreateCommentDTO request, Long postId, UUID userId);
+    List<CommentResponseDTO> getRootCommentsByPost(Long postId);
+    Page<CommentResponseDTO> getChildrenByRoot(Long rootCommentId, Pageable pageable);
+    CommentResponseDTO getCommentDetail(Long commentId);
+    CommentThreadResponseDTO getThreadByRoot(Long commentId);
+    CommentResponseDTO updateComment(Long commentId, UUID userId, String content);
+    void deleteComment(Long commentId, UUID userId);
+    Long getCommentCountForPost(Long postId);
+
+    Page<CommentResponseDTO> getMyComments(UUID userId, Pageable pageable);
+}

--- a/src/main/java/Bubble/bubblog/domain/comment/service/commentservice/CommentServiceImpl.java
+++ b/src/main/java/Bubble/bubblog/domain/comment/service/commentservice/CommentServiceImpl.java
@@ -1,0 +1,230 @@
+package Bubble.bubblog.domain.comment.service.commentservice;
+
+import Bubble.bubblog.domain.comment.dto.CommentMapper;
+import Bubble.bubblog.domain.comment.dto.ReplyCount;
+import Bubble.bubblog.domain.comment.dto.req.CreateCommentDTO;
+import Bubble.bubblog.domain.comment.dto.res.CommentResponseDTO;
+import Bubble.bubblog.domain.comment.dto.res.CommentThreadResponseDTO;
+import Bubble.bubblog.domain.comment.entity.Comment;
+import Bubble.bubblog.domain.comment.repository.CommentRepository;
+import Bubble.bubblog.domain.post.entity.BlogPost;
+import Bubble.bubblog.domain.post.repository.BlogPostRepository;
+import Bubble.bubblog.domain.user.entity.User;
+import Bubble.bubblog.domain.user.repository.UserRepository;
+import Bubble.bubblog.global.exception.CustomException;
+import Bubble.bubblog.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class CommentServiceImpl implements CommentService {
+    private final BlogPostRepository blogPostRepository;
+    private final UserRepository userRepository;
+    private final CommentRepository commentRepository;
+    private final CommentMapper commentMapper;
+
+
+    /** 댓글 생성 */
+    @Transactional
+    @Override
+    public CommentResponseDTO createComment(CreateCommentDTO request, Long postId, UUID userId) {
+        BlogPost blogPost = blogPostRepository.findById(postId)
+                .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        Comment comment;
+
+        if (request.getParentId() != null) {    // 대댓글 생성
+            Comment parentComment = commentRepository.findById(request.getParentId())
+                    .orElseThrow(() -> new CustomException(ErrorCode.PARENT_COMMENT_NOT_FOUND));
+
+            if (parentComment.getParent() != null) {
+                throw new CustomException(ErrorCode.REPLY_TO_REPLY_NOT_ALLOWED);
+            }
+
+            if (!parentComment.getPost().getId().equals(postId)) {
+                throw new CustomException(ErrorCode.INVALID_PARENT_FOR_POST);
+            }
+
+            if (parentComment.getIsDeleted()) {
+                throw new CustomException(ErrorCode.REPLY_TO_DELETED_COMMENT_NOT_ALLOWED);
+            }
+
+            comment = Comment.createReply(request.getContent(), blogPost, user, parentComment);
+            commentRepository.save(comment);
+
+            // 자식 응답: parentId 세팅, replyCount=null
+            return commentMapper.toChild(comment);
+
+        } else {
+            // 루트 댓글 생성
+            comment = Comment.createComment(request.getContent(), blogPost, user);
+            commentRepository.save(comment);
+
+            // 루트 응답: parentId=null, replyCount=0L
+            return commentMapper.toRoot(comment, 0L);
+        }
+
+    }
+
+
+    /** 특정 게시글의 루트 댓글 목록 조회 */
+    @Transactional(readOnly = true)
+    @Override
+    public List<CommentResponseDTO> getRootCommentsByPost(Long postId) {
+        
+        // 루트 댓글 리스트 조회
+        List<Comment> rootComments = commentRepository.findRootCommentsByPostId(postId);
+        if (rootComments.isEmpty()) return List.of();
+
+        // 루트 댓글들의 ID만 뽑아서 집계 쿼리 호출 -> (rootId, cnt) 리스트를 맵으로 변환
+        Map<Long, Long> replyCount = commentRepository.countByParentIds(rootComments.stream().map(Comment::getId).toList())
+                .stream()
+                .collect(Collectors.toMap(
+                        ReplyCount::getRootId,
+                        ReplyCount::getCnt
+                ));
+
+        // Mapper에게 root와 cnt 전달. replyCount 맵에서 rootId 키가 존재하면 해당 cnt를, 존재하지 않으면 0L를 반환
+        return rootComments.stream()
+                .map(root -> commentMapper.toRoot(root, replyCount.getOrDefault(root.getId(), 0L)))
+                .toList();
+    }
+
+
+    /** 특정 루트에 대한 자식 목록 조회(페이징) */
+    @Transactional(readOnly = true)
+    @Override
+    public Page<CommentResponseDTO> getChildrenByRoot(Long commentId, Pageable pageable) {
+        // 루트 댓글 존재 여부 확인 - user와 fetch join해서 불러올 필요가 없으므로 findById로 찾는다.
+        Comment rootComment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new CustomException(ErrorCode.COMMENT_NOT_FOUND));
+
+        if (rootComment.getParent() != null) {
+            throw new CustomException(ErrorCode.NOT_ROOT_COMMENT);
+        }
+
+        // 특정 루트 댓글의 자식들만 페이징하여 조회
+        Page<Comment> children = commentRepository.findChildrenByParentId(commentId, pageable);
+
+        return children.map(commentMapper::toChild);
+    }
+
+
+    /** 특정 댓글 단건 조회 */
+    @Transactional(readOnly = true)
+    @Override
+    public CommentResponseDTO getCommentDetail(Long commentId) {
+        Comment comment = commentRepository.findByIdWithUser(commentId)
+                .orElseThrow(() -> new CustomException(ErrorCode.COMMENT_NOT_FOUND));
+
+        long replyCount = 0L;
+
+        if (comment.getParent() == null) {      // 루트 댓글인 경우에만 집계, 조회하고자하는 댓글이 자식 댓글이라면 replyCount는 null
+            replyCount = commentRepository.countByParentId(comment.getId());
+
+            return commentMapper.toRoot(comment, replyCount);
+        }
+
+        return commentMapper.toChild(comment);
+
+    }
+
+
+    /** 댓글 수정 */
+    @Transactional
+    @Override
+    public CommentResponseDTO updateComment(Long commentId, UUID userId, String content) {
+        Comment comment = commentRepository.findByIdWithUser(commentId)
+                .orElseThrow(() -> new CustomException(ErrorCode.COMMENT_NOT_FOUND));
+
+        if (!comment.getUser().getId().equals(userId)) {
+            throw new CustomException(ErrorCode.NO_PERMISSION_TO_EDIT_COMMENT);
+        }
+
+        comment.updateContent(content);
+
+        if (comment.getParent() != null) {    // 수정한 댓글이 부모가 존재한다면
+            return commentMapper.toChild(comment);
+
+        } else {  // 수정한 댓글이 루트 댓글이라면
+            long replyCount = commentRepository.countByParentId(commentId);
+            return commentMapper.toRoot(comment, replyCount);
+        }
+    }
+
+
+    /** 댓글 삭제 */
+    @Transactional
+    @Override
+    public void deleteComment(Long commentId, UUID userId) {
+        Comment comment = commentRepository.findById(commentId)   // user 닉네임이나 프로필 이미지가 필요없으니 fetch join 하지 않는 findById로!
+                .orElseThrow(() -> new CustomException(ErrorCode.COMMENT_NOT_FOUND));
+
+        if (!comment.getUser().getId().equals(userId)) {
+            throw new CustomException(ErrorCode.NO_PERMISSION_TO_DELETE_COMMENT);
+        }
+
+        comment.softDelete(); // isDeleted = true, deletedAt 생성
+    }
+
+
+    /** 특정 루트 댓글을 그의 모든 자식들과 함께 조회 (스레드 조회) */
+    @Transactional(readOnly = true)
+    @Override
+    public CommentThreadResponseDTO getThreadByRoot(Long commentId) {
+        Comment rootComment = commentRepository.findByIdWithUser(commentId)
+                .orElseThrow(() -> new CustomException(ErrorCode.COMMENT_NOT_FOUND));
+
+        if (rootComment.getParent() != null) {  // 자식 id가 들어오면 예외 처리
+            throw new CustomException(ErrorCode.NOT_ROOT_COMMENT);
+        }
+
+        List<Comment> children = commentRepository.findChildrenByRootIdForThread(commentId);
+        long replyCount = children.size(); // 이미 로딩됨 → 추가 쿼리 없음
+
+        return commentMapper.toThread(rootComment, replyCount, children);
+    }
+
+
+    /** 게시글 전체 댓글 수 조회 */
+    @Transactional(readOnly = true)
+    @Override
+    public Long getCommentCountForPost(Long postId) {
+        // postId에 해당하는 게시글이 존재하는지 확인
+        if (!blogPostRepository.existsById(postId)) {
+            throw new CustomException(ErrorCode.POST_NOT_FOUND);
+        }
+        return commentRepository.countByPostId(postId);
+    }
+
+
+    /** 내가 쓴 댓글 목록 조회 */
+    @Transactional(readOnly = true)
+    @Override
+    public Page<CommentResponseDTO> getMyComments(UUID userId, Pageable pageable) {
+        // userId로 댓글을 찾고, DTO로 변환하여 반환
+        Page<Comment> comments = commentRepository.findByUserId(userId, pageable);
+
+        // 각 댓글에 대한 답글 수 집계 (루트 댓글인 경우)
+        return comments.map(comment -> {
+            Long replyCount = null;
+            if (comment.getParent() == null) {
+                replyCount = commentRepository.countByParentId(comment.getId());
+                return commentMapper.toRoot(comment, replyCount);
+            }
+            return commentMapper.toChild(comment);
+        });
+    }
+}

--- a/src/main/java/Bubble/bubblog/domain/post/controller/BlogPostController.java
+++ b/src/main/java/Bubble/bubblog/domain/post/controller/BlogPostController.java
@@ -35,6 +35,7 @@ import java.util.UUID;
 public class BlogPostController {
 
     private final BlogPostService blogPostService;
+    // private final TagService tagService;
 
     // 게시글 생성
     @Operation(summary = "게시글 생성", description = "사용자가 새 게시글을 작성합니다.", security = @SecurityRequirement(name = "JWT"))
@@ -153,6 +154,15 @@ public class BlogPostController {
         return SuccessResponse.of(blogPostService.getLikedPosts(userId, pageable));
     }
 
+    @Operation(summary = "태그 기반 게시글 조회", description = "특정 태그가 포함된 공개 게시글들을 조회합니다.")
+    @GetMapping("/tags/{tagId}")
+    public SuccessResponse<Page<BlogPostSummaryDTO>> getPostsByTag(
+            @PathVariable Long tagId,
+            @ParameterObject @PageableDefault(size = 6, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+
+        return SuccessResponse.of(blogPostService.getPostsByTagId(tagId, pageable));
+    }
+
     // 게시글 삭제
     @Operation(summary = "게시글 삭제", description = "게시글을 삭제합니다.", security = @SecurityRequirement(name = "JWT"))
     @ApiResponses({
@@ -218,5 +228,12 @@ public class BlogPostController {
         blogPostService.incrementViewCount(postId);
         return SuccessResponse.of();
     }
+
+// 현재는 게시글 상세 조회에서 DTO에 태그를 포함하는데 혹시 필요할까봐 작성한 API
+//    // 특정 게시글의 tag 목록 조회
+//    @GetMapping("/{postId}/tags")
+//    public List<TagResponseDTO> getTagsForPost(@PathVariable Long postId) {
+//        return tagService.getTagsForPost(postId);
+//    }
 
 }

--- a/src/main/java/Bubble/bubblog/domain/post/dto/req/BlogPostRequestDTO.java
+++ b/src/main/java/Bubble/bubblog/domain/post/dto/req/BlogPostRequestDTO.java
@@ -4,9 +4,13 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import lombok.Builder;
 import lombok.Getter;
 
+import java.util.List;
+
 @Getter
+@Builder
 @Schema(description = "블로그 게시글 작성 요청 DTO")
 public class BlogPostRequestDTO {
 
@@ -32,4 +36,7 @@ public class BlogPostRequestDTO {
 
     @Schema(description = "썸네일 URL", example = "https://bucketName.s3.amazonaws.com/images/@#@#@#_hanhwaeagles.jpg")
     private String thumbnailUrl;
+
+    @Schema(description = "태그 리스트", example = "[\"spring\", \"jpa\"]")
+    private List<String> tags;
 }

--- a/src/main/java/Bubble/bubblog/domain/post/dto/res/BlogPostDetailDTO.java
+++ b/src/main/java/Bubble/bubblog/domain/post/dto/res/BlogPostDetailDTO.java
@@ -24,8 +24,9 @@ public class BlogPostDetailDTO {
     private UUID userId;
     private String nickname;
     private List<String> categoryList;
+    private List<String> tags;
 
-    public BlogPostDetailDTO(BlogPost post, List<String> categoryList) {
+    public BlogPostDetailDTO(BlogPost post, List<String> categoryList, List<String> tags) {
         this.id = post.getId();
         this.title = post.getTitle();
         this.content = post.getContent();
@@ -39,5 +40,6 @@ public class BlogPostDetailDTO {
         this.userId = post.getUser().getId();
         this.nickname = post.getUser().getNickname();
         this.categoryList = categoryList;
+        this.tags = tags;
     }
 }

--- a/src/main/java/Bubble/bubblog/domain/post/entity/BlogPost.java
+++ b/src/main/java/Bubble/bubblog/domain/post/entity/BlogPost.java
@@ -1,6 +1,8 @@
 package Bubble.bubblog.domain.post.entity;
 
 import Bubble.bubblog.domain.category.entity.Category;
+import Bubble.bubblog.domain.tag.entity.PostTag;
+import Bubble.bubblog.domain.tag.entity.Tag;
 import Bubble.bubblog.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -58,8 +60,12 @@ public class BlogPost {
     @Column(name = "like_count", nullable = false)
     private Long likeCount = 0L;
 
-    @OneToMany(mappedBy = "post", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    @OneToMany(mappedBy = "post", cascade = CascadeType.REMOVE)
     private List<PostLike> likes = new ArrayList<>();
+
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
+    private List<PostTag> postTags = new ArrayList<>();
+
 
     private BlogPost(String title, String content, String summary,
                      boolean isPublic, String thumbnailUrl,
@@ -108,4 +114,12 @@ public class BlogPost {
             this.likeCount -= 1;
         }
     }
+
+    public void addTag(Tag tag) {
+        PostTag postTag = new PostTag(this, tag);
+        this.postTags.add(postTag);
+        tag.getPostTags().add(postTag); // 양방향 연관관계 유지
+    }
+
+
 }

--- a/src/main/java/Bubble/bubblog/domain/post/entity/BlogPost.java
+++ b/src/main/java/Bubble/bubblog/domain/post/entity/BlogPost.java
@@ -67,7 +67,7 @@ public class BlogPost {
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
     private List<PostTag> postTags = new ArrayList<>();
 
-    @OneToMany(mappedBy = "blogPost", fetch = FetchType.LAZY)  // Soft delete 이므로 CASCADE 설정 X
+    @OneToMany(mappedBy = "post", fetch = FetchType.LAZY)  // Soft delete 이므로 CASCADE 설정 X
     private List<Comment> comments;
 
 

--- a/src/main/java/Bubble/bubblog/domain/post/entity/BlogPost.java
+++ b/src/main/java/Bubble/bubblog/domain/post/entity/BlogPost.java
@@ -1,6 +1,7 @@
 package Bubble.bubblog.domain.post.entity;
 
 import Bubble.bubblog.domain.category.entity.Category;
+import Bubble.bubblog.domain.comment.entity.Comment;
 import Bubble.bubblog.domain.tag.entity.PostTag;
 import Bubble.bubblog.domain.tag.entity.Tag;
 import Bubble.bubblog.domain.user.entity.User;
@@ -65,6 +66,9 @@ public class BlogPost {
 
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
     private List<PostTag> postTags = new ArrayList<>();
+
+    @OneToMany(mappedBy = "blogPost", fetch = FetchType.LAZY)  // Soft delete 이므로 CASCADE 설정 X
+    private List<Comment> comments;
 
 
     private BlogPost(String title, String content, String summary,

--- a/src/main/java/Bubble/bubblog/domain/post/entity/PostLike.java
+++ b/src/main/java/Bubble/bubblog/domain/post/entity/PostLike.java
@@ -4,8 +4,6 @@ import Bubble.bubblog.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.OnDelete;
-import org.hibernate.annotations.OnDeleteAction;
 
 // 유저 - 게시글 사이의 좋아요 관계를 정의한 엔티티
 @Entity
@@ -21,12 +19,10 @@ public class PostLike {
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "user_id", nullable = false, foreignKey = @ForeignKey(name = "fk_like_user"))
-    @OnDelete(action = OnDeleteAction.CASCADE)
     private User user;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id", nullable = false, foreignKey = @ForeignKey(name = "fk_like_post"))
-    @OnDelete(action = OnDeleteAction.CASCADE)
     private BlogPost post;
 
     public PostLike(User user, BlogPost post) {

--- a/src/main/java/Bubble/bubblog/domain/post/repository/BlogPostRepository.java
+++ b/src/main/java/Bubble/bubblog/domain/post/repository/BlogPostRepository.java
@@ -1,6 +1,7 @@
 package Bubble.bubblog.domain.post.repository;
 
 import Bubble.bubblog.domain.post.entity.BlogPost;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
@@ -8,6 +9,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface BlogPostRepository extends JpaRepository<BlogPost, Long>, BlogPostRepositoryCustom {
@@ -38,4 +40,15 @@ public interface BlogPostRepository extends JpaRepository<BlogPost, Long>, BlogP
             List<Long> categoryIds,
             Pageable pageable
     );
+
+    // 게시글 상세 조회 JPA
+    @EntityGraph(attributePaths = {"postTags", "postTags.tag", "category", "user"})
+    @Query("SELECT bp FROM BlogPost bp WHERE bp.id = :id")
+    Optional<BlogPost> findDetailById(Long id);
+
+    // 태그ID 기반 게시글 목록 조회
+    @EntityGraph(attributePaths = {"category", "user"})
+    @Query("SELECT bp FROM BlogPost bp JOIN bp.postTags pt WHERE pt.tag.id = :tagId AND bp.publicVisible = true")
+    Page<BlogPost> findPublicPostsByTagId(@Param("tagId") Long tagId, Pageable pageable);
+
 }

--- a/src/main/java/Bubble/bubblog/domain/post/repository/BlogPostRepository.java
+++ b/src/main/java/Bubble/bubblog/domain/post/repository/BlogPostRepository.java
@@ -51,4 +51,11 @@ public interface BlogPostRepository extends JpaRepository<BlogPost, Long>, BlogP
     @Query("SELECT bp FROM BlogPost bp JOIN bp.postTags pt WHERE pt.tag.id = :tagId AND bp.publicVisible = true")
     Page<BlogPost> findPublicPostsByTagId(@Param("tagId") Long tagId, Pageable pageable);
 
+    // 내가 쓴 게시글 중 다른 사람의 댓글이 존재하는 게시글 목록 조회 (Comment의 필드를 직접적으로 사용하지 않으므로 fetch join 할 필요 없다.)
+    @Query(value = """
+        SELECT DISTINCT bp FROM BlogPost bp
+        JOIN bp.comments c
+        WHERE bp.user.id = :userId AND c.isDeleted = false AND c.user.id != :userId
+    """)
+    Page<BlogPost> findByUserAndCommentExists(@Param("userId") UUID userId, Pageable pageable);
 }

--- a/src/main/java/Bubble/bubblog/domain/post/repository/PostLikeRepository.java
+++ b/src/main/java/Bubble/bubblog/domain/post/repository/PostLikeRepository.java
@@ -6,21 +6,15 @@ import Bubble.bubblog.domain.user.entity.User;
 import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
+import java.util.UUID;
 
 public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
     Optional<PostLike> findByUserAndPost(User user, BlogPost post);
 
-    @EntityGraph(attributePaths = {"user"})
-    @Query("""
-        SELECT p FROM BlogPost p
-        WHERE p IN (
-            SELECT pl.post FROM PostLike pl WHERE pl.user = :user
-        )
-    """)
-    Page<BlogPost> findLikedPostsByUser(@Param("user") User user, Pageable pageable);
+    @Query("SELECT pl.post FROM PostLike pl WHERE pl.user.id = :userId")  // JPQL
+    Page<BlogPost> findLikedPostsByUser(@Param("userId") UUID userId, Pageable pageable);
 }

--- a/src/main/java/Bubble/bubblog/domain/post/service/BlogPostService.java
+++ b/src/main/java/Bubble/bubblog/domain/post/service/BlogPostService.java
@@ -11,9 +11,10 @@ import java.util.UUID;
 
 public interface BlogPostService {
     BlogPostDetailDTO createPost(BlogPostRequestDTO request, UUID userId);
-    BlogPostDetailDTO getPost(Long postId, UUID userId);
+    BlogPostDetailDTO getPost(Long postId);
     Page<BlogPostSummaryDTO> getAllPosts(String keyword, Pageable pageable);
-    UserPostsResponseDTO getPostsByUser(UUID targetUserId, UUID requesterUserId, Long categoryId, Pageable pageable);
+    UserPostsResponseDTO getPostsByUser(UUID targetUserId, Long categoryId, Pageable pageable);
+    Page<BlogPostSummaryDTO> getLikedPosts(UUID userId, Pageable pageable);
     void deletePost(Long postId, UUID userId);
     BlogPostDetailDTO updatePost(Long postId, BlogPostRequestDTO request, UUID userId);
 

--- a/src/main/java/Bubble/bubblog/domain/post/service/BlogPostService.java
+++ b/src/main/java/Bubble/bubblog/domain/post/service/BlogPostService.java
@@ -15,6 +15,7 @@ public interface BlogPostService {
     Page<BlogPostSummaryDTO> getAllPosts(String keyword, Pageable pageable);
     UserPostsResponseDTO getPostsByUser(UUID targetUserId, Long categoryId, Pageable pageable);
     Page<BlogPostSummaryDTO> getLikedPosts(UUID userId, Pageable pageable);
+    Page<BlogPostSummaryDTO> getPostsByTagId(Long tagId, Pageable pageable);
     void deletePost(Long postId, UUID userId);
     BlogPostDetailDTO updatePost(Long postId, BlogPostRequestDTO request, UUID userId);
 

--- a/src/main/java/Bubble/bubblog/domain/post/service/BlogPostService.java
+++ b/src/main/java/Bubble/bubblog/domain/post/service/BlogPostService.java
@@ -21,4 +21,8 @@ public interface BlogPostService {
 
     boolean toggleLike(Long postId, UUID userId); // 좋아요 토글 (좋아요/취소)
     void incrementViewCount(Long postId);
+
+    Page<BlogPostSummaryDTO> getMyCommentedPosts(UUID userId, Pageable pageable);
+
+    Page<BlogPostSummaryDTO> getMyPostsWithComments(UUID userId, Pageable pageable);
 }

--- a/src/main/java/Bubble/bubblog/domain/tag/controller/TagController.java
+++ b/src/main/java/Bubble/bubblog/domain/tag/controller/TagController.java
@@ -1,0 +1,61 @@
+package Bubble.bubblog.domain.tag.controller;
+
+import Bubble.bubblog.domain.tag.dto.res.TagResponseDTO;
+import Bubble.bubblog.domain.tag.service.TagService;
+import Bubble.bubblog.global.dto.SuccessResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/tags")
+@Tag(name = "Tag", description = "태그 관련 API")
+public class TagController {
+
+    private final TagService tagService;
+
+    @Operation(summary = "태그 목록 조회", description = "전체 태그 목록을 조회.", security = @SecurityRequirement(name = "JWT"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "태그 목록 조회 성공",
+                    content = @Content(schema = @Schema(implementation = SuccessResponse.class))),
+    })
+    @GetMapping
+    public List<TagResponseDTO> getAllTags() {
+        return tagService.getAllTags();
+    }
+
+    @Operation(summary = "태그 상세 조회", description = "특정 태그를 조회.", security = @SecurityRequirement(name = "JWT"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "게시글 생성 성공",
+                    content = @Content(schema = @Schema(implementation = SuccessResponse.class))),
+    })
+    @GetMapping("/{id}")
+    public TagResponseDTO getTag(@PathVariable Long id) {
+        return tagService.getTag(id);
+    }
+
+//    @Operation(summary = "태그 생성", description = "태그를 생성합니다.", security = @SecurityRequirement(name = "JWT"))
+//    @ApiResponses({
+//            @ApiResponse(responseCode = "200", description = "태그 생성 성공",
+//                    content = @Content(schema = @Schema(implementation = SuccessResponse.class))),
+//            @ApiResponse(responseCode = "400", description = "입력값이 유효하지 않음",
+//                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+//    })
+//    @PostMapping
+//    public ResponseEntity<TagResponseDTO> createTag(@RequestBody @Valid TagRequestDTO request) {
+//        TagResponseDTO response = tagService.createTag(request);
+//        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+//    }
+}

--- a/src/main/java/Bubble/bubblog/domain/tag/dto/req/TagRequestDTO.java
+++ b/src/main/java/Bubble/bubblog/domain/tag/dto/req/TagRequestDTO.java
@@ -1,0 +1,17 @@
+package Bubble.bubblog.domain.tag.dto.req;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Schema(description = "챗봇 말투 생성 요청 DTO")
+@NoArgsConstructor   // 기본 생성자 자동 생성 (Jackson이 JSON을 자바 객체로 역직렬화 할 때 기본 생성자 필요)
+public class TagRequestDTO {
+    @Schema(description = "태그 이름", example = "Spring")
+    @NotBlank(message = "태그명은 필수 입력값입니다.")
+    @Size(max = 50, message = "태그명은 최대 50자까지 가능합니다.")
+    private String name;
+}

--- a/src/main/java/Bubble/bubblog/domain/tag/dto/res/TagResponseDTO.java
+++ b/src/main/java/Bubble/bubblog/domain/tag/dto/res/TagResponseDTO.java
@@ -1,0 +1,15 @@
+package Bubble.bubblog.domain.tag.dto.res;
+
+import Bubble.bubblog.domain.tag.entity.Tag;
+import lombok.Getter;
+
+@Getter
+public class TagResponseDTO {
+    private Long id;
+    private String name;
+
+    public TagResponseDTO(Tag tag) {   // new TagResponseDTO(tag)로 DTO 생성
+        this.id = tag.getId();
+        this.name = tag.getName();
+    }
+}

--- a/src/main/java/Bubble/bubblog/domain/tag/entity/PostTag.java
+++ b/src/main/java/Bubble/bubblog/domain/tag/entity/PostTag.java
@@ -1,0 +1,29 @@
+package Bubble.bubblog.domain.tag.entity;
+
+import Bubble.bubblog.domain.post.entity.BlogPost;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "post_tag", uniqueConstraints = @UniqueConstraint(columnNames = {"post_id", "tag_id"}))
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostTag {    // blog_post <-> tag 다대다 관계 테이블
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false, foreignKey = @ForeignKey(name = "fk_posttag_post"))
+    private BlogPost post;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "tag_id", nullable = false, foreignKey = @ForeignKey(name = "fk_posttag_tag"))
+    private Tag tag;
+
+    public PostTag(BlogPost post, Tag tag) {
+        this.post = post;
+        this.tag = tag;
+    }
+}

--- a/src/main/java/Bubble/bubblog/domain/tag/entity/Tag.java
+++ b/src/main/java/Bubble/bubblog/domain/tag/entity/Tag.java
@@ -1,0 +1,30 @@
+package Bubble.bubblog.domain.tag.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "tag")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Tag {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true, nullable = false, length = 50)
+    private String name;
+
+    @OneToMany(mappedBy = "tag", cascade = CascadeType.ALL)
+    private List<PostTag> postTags = new ArrayList<>();
+
+    public Tag(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/Bubble/bubblog/domain/tag/repository/PostTagRepository.java
+++ b/src/main/java/Bubble/bubblog/domain/tag/repository/PostTagRepository.java
@@ -1,0 +1,19 @@
+package Bubble.bubblog.domain.tag.repository;
+
+import Bubble.bubblog.domain.post.entity.BlogPost;
+import Bubble.bubblog.domain.tag.entity.PostTag;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+public interface PostTagRepository extends JpaRepository<PostTag, Long> {
+    List<PostTag> findAllByPost(BlogPost post);
+
+    @Modifying(clearAutomatically = true)
+    @Transactional
+    @Query("DELETE FROM PostTag pt WHERE pt.post = :post")
+    void deleteByPost(BlogPost post);
+}

--- a/src/main/java/Bubble/bubblog/domain/tag/repository/TagRepository.java
+++ b/src/main/java/Bubble/bubblog/domain/tag/repository/TagRepository.java
@@ -1,0 +1,10 @@
+package Bubble.bubblog.domain.tag.repository;
+
+import Bubble.bubblog.domain.tag.entity.Tag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface TagRepository extends JpaRepository<Tag, Long> {
+    Optional<Tag> findByName(String name);
+}

--- a/src/main/java/Bubble/bubblog/domain/tag/service/TagService.java
+++ b/src/main/java/Bubble/bubblog/domain/tag/service/TagService.java
@@ -1,0 +1,17 @@
+package Bubble.bubblog.domain.tag.service;
+
+import Bubble.bubblog.domain.tag.dto.res.TagResponseDTO;
+
+import java.util.List;
+
+public interface TagService {
+    List<TagResponseDTO> getAllTags();
+    TagResponseDTO getTag(Long id);
+
+//    게시글 생성 시 태그 자동 추출해서 필요없음 - 필요할까봐 미리 만든 API
+//    TagResponseDTO createTag(TagRequestDTO request);
+
+// 현재는 게시글 상세 조회에서 DTO에 태그를 포함하는데 혹시 필요할까봐 작성한 API
+//    // 특정 게시글에 연결된 태그 목록 조회
+//    List<TagResponseDTO> getTagsForPost(Long postId);
+}

--- a/src/main/java/Bubble/bubblog/domain/tag/service/TagServiceImpl.java
+++ b/src/main/java/Bubble/bubblog/domain/tag/service/TagServiceImpl.java
@@ -1,0 +1,70 @@
+package Bubble.bubblog.domain.tag.service;
+
+import Bubble.bubblog.domain.tag.dto.res.TagResponseDTO;
+import Bubble.bubblog.domain.tag.entity.Tag;
+import Bubble.bubblog.domain.tag.repository.TagRepository;
+import Bubble.bubblog.global.exception.CustomException;
+import Bubble.bubblog.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class TagServiceImpl implements TagService {
+
+    private final TagRepository tagRepository;
+    //private final BlogPostRepository blogPostRepository;
+    //private final PostTagRepository postTagRepository;
+
+    // 태그 전체 조회
+    @Override
+    @Transactional(readOnly = true)
+    public List<TagResponseDTO> getAllTags() {
+        return tagRepository.findAll().stream()
+                .map(TagResponseDTO::new)
+                .collect(Collectors.toList());
+    }
+
+    // 태그 조회
+    @Override
+    @Transactional(readOnly = true)
+    public TagResponseDTO getTag(Long id) {
+        Tag tag = tagRepository.findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.TAG_NOT_FOUND));
+        return new TagResponseDTO(tag);
+    }
+
+// 게시글 생성 시 태그 자동 추출해서 필요없음 - 필요할까봐 미리 만든 API
+//    // 태그 생성
+//    @Override
+//    @Transactional
+//    public TagResponseDTO createTag(TagRequestDTO request) {
+//        // 중복 이름 체크
+//        tagRepository.findByName(request.getName()).ifPresent(tag -> {
+//            throw new CustomException(ErrorCode.DUPLICATE_TAG);
+//        });
+//
+//        Tag tag = tagRepository.save(new Tag(request.getName()));
+//        return new TagResponseDTO(tag);
+//    }
+
+// 현재는 게시글 상세 조회에서 DTO에 태그를 포함하는데 혹시 필요할까봐 작성한 API
+//    // 특정 게시글의 태그 목록 조회
+//    @Override
+//    @Transactional(readOnly = true)
+//    public List<TagResponseDTO> getTagsForPost(Long postId) {
+//        BlogPost post = blogPostRepository.findById(postId)
+//                .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
+//
+//        List<PostTag> postTags = postTagRepository.findAllByPost(post);
+//
+//        return postTags.stream()
+//                .map(pt -> new TagResponseDTO(pt.getTag()))
+//                .collect(Collectors.toList());
+//    }
+}
+

--- a/src/main/java/Bubble/bubblog/domain/user/controller/AuthController.java
+++ b/src/main/java/Bubble/bubblog/domain/user/controller/AuthController.java
@@ -6,7 +6,7 @@ import Bubble.bubblog.domain.user.dto.authRes.TokensDTO;
 import Bubble.bubblog.domain.user.dto.req.LoginRequestDTO;
 import Bubble.bubblog.domain.user.dto.req.SignupRequestDTO;
 import Bubble.bubblog.domain.user.entity.User;
-import Bubble.bubblog.domain.user.service.UserService;
+import Bubble.bubblog.domain.user.service.UserAuthService;
 import Bubble.bubblog.global.dto.ErrorResponse;
 import Bubble.bubblog.global.dto.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -34,7 +34,7 @@ import java.util.UUID;
 @RequestMapping(value = "/api/auth", produces = "application/json")
 public class AuthController {
 
-    private final UserService userService;
+    private final UserAuthService userAuthService;
 
     @Operation(summary = "회원가입", description = "새로운 사용자를 등록합니다.")
     @ApiResponses({
@@ -45,7 +45,7 @@ public class AuthController {
     })
     @PostMapping("/signup")
     public SuccessResponse<Void> signup(@RequestBody SignupRequestDTO request) {
-        userService.signup(request);
+        userAuthService.signup(request);
         return SuccessResponse.of();
     }
 
@@ -58,8 +58,8 @@ public class AuthController {
     })
     @PostMapping("/login")
     public SuccessResponse<LoginResponseDTO> login(@Valid @RequestBody LoginRequestDTO request, HttpServletResponse response) {
-        User user = userService.login(request); // User 객체 반환
-        TokensDTO tokens = userService.issueTokens(user.getId());
+        User user = userAuthService.login(request); // User 객체 반환
+        TokensDTO tokens = userAuthService.issueTokens(user.getId());
 
         ResponseCookie refreshTokenCookie = ResponseCookie.from("refreshToken", tokens.getRefreshToken())
                 .httpOnly(true)
@@ -90,7 +90,7 @@ public class AuthController {
                                     @CookieValue("refreshToken") String refreshToken,
                                     HttpServletResponse response) {
 
-        userService.logout(userId); // Redis에서 삭제
+        userAuthService.logout(userId); // Redis에서 삭제
 
         // 쿠키 제거 (maxAge=0)
         ResponseCookie deleteCookie = ResponseCookie.from("refreshToken", "")
@@ -117,7 +117,7 @@ public class AuthController {
     @PostMapping("/reissue")
     public SuccessResponse<ReissueResponseDTO> reissue(@CookieValue("refreshToken") String refreshToken,
                                                        HttpServletResponse response) {       // @RequestBody ReissueRequestDTO request
-        TokensDTO newtokens = userService.reissueTokens(refreshToken);
+        TokensDTO newtokens = userAuthService.reissueTokens(refreshToken);
         ResponseCookie refreshTokenCookie = ResponseCookie.from("refreshToken", newtokens.getRefreshToken())
                 .httpOnly(true)
                 .secure(true)

--- a/src/main/java/Bubble/bubblog/domain/user/controller/UserInfoController.java
+++ b/src/main/java/Bubble/bubblog/domain/user/controller/UserInfoController.java
@@ -1,7 +1,11 @@
 package Bubble.bubblog.domain.user.controller;
 
+import Bubble.bubblog.domain.comment.dto.res.CommentResponseDTO;
+import Bubble.bubblog.domain.comment.service.commentservice.CommentService;
 import Bubble.bubblog.domain.post.dto.res.BlogPostDetailDTO;
+import Bubble.bubblog.domain.post.dto.res.BlogPostSummaryDTO;
 import Bubble.bubblog.domain.post.dto.res.UserPostsResponseDTO;
+import Bubble.bubblog.domain.post.service.BlogPostService;
 import Bubble.bubblog.domain.user.dto.infoRes.UserInfoDTO;
 import Bubble.bubblog.domain.user.dto.req.UserUpdateDTO;
 import Bubble.bubblog.domain.user.service.UserInfoService;
@@ -18,6 +22,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
@@ -33,55 +38,45 @@ import java.util.UUID;
 public class UserInfoController {
 
     private final UserInfoService userInfoService;
+    private final BlogPostService blogPostService;
+    private final CommentService commentService;
 
     @Operation(summary = "사용자 정보 조회", description = "특정 사용자의 정보를 조회합니다.")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "조회 성공",
-                    content = @Content(schema = @Schema(implementation = SuccessResponse.class))),
-            @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            @ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(schema = @Schema(implementation = SuccessResponse.class))),
+            @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @GetMapping("/{userId}")
-    public SuccessResponse<UserInfoDTO> getUserInfo(
-            @PathVariable UUID userId) {
+    public SuccessResponse<UserInfoDTO> getUserInfo(@PathVariable UUID userId) {
         return SuccessResponse.of(userInfoService.getUserInfo(userId));
     }
 
     @Operation(summary = "사용자 정보 수정", description = "현재 로그인된 유저의 정보를 수정합니다.", security = @SecurityRequirement(name = "JWT"))
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "수정 성공",
-                    content = @Content(schema = @Schema(implementation = SuccessResponse.class))),
-            @ApiResponse(responseCode = "404", description = "해당 사용자를 찾을 수 없음",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "400", description = "입력값 오류 혹은 닉네임 중복",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            @ApiResponse(responseCode = "200", description = "수정 성공", content = @Content(schema = @Schema(implementation = SuccessResponse.class))),
+            @ApiResponse(responseCode = "404", description = "해당 사용자를 찾을 수 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "400", description = "입력값 오류 혹은 닉네임 중복", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @PutMapping("/me")
-    public SuccessResponse<Void> updateUser(
-            @Valid @RequestBody UserUpdateDTO request,
-            @Parameter(hidden = true) @AuthenticationPrincipal UUID userId) {
+    public SuccessResponse<Void> updateUser(@Valid @RequestBody UserUpdateDTO request,
+                                            @Parameter(hidden = true) @AuthenticationPrincipal UUID userId) {
         userInfoService.updateUser(userId, request);
         return SuccessResponse.of();
     }
 
-    // 나의 게시글 상세 조회 (공개 및 비공개 포함)
     @Operation(summary = "나의 게시글 상세 조회", description = "로그인한 사용자의 특정 게시글 상세 정보를 조회합니다.", security = @SecurityRequirement(name = "JWT"))
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "조회 성공",
-                    content = @Content(schema = @Schema(implementation = SuccessResponse.class))),
-            @ApiResponse(responseCode = "403", description = "접근 권한 없음",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "404", description = "게시글을 찾을 수 없음",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            @ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(schema = @Schema(implementation = SuccessResponse.class))),
+            @ApiResponse(responseCode = "403", description = "접근 권한 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "게시글을 찾을 수 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    @GetMapping("/me/posts/{postId}") // 새로운 URL 경로
+    @GetMapping("/me/posts/{postId}")
     public SuccessResponse<BlogPostDetailDTO> getMyPost(
             @PathVariable Long postId,
             @Parameter(hidden = true) @AuthenticationPrincipal UUID userId) {     // userId를 @AuthenticationPrincipal로 받음
         return SuccessResponse.of(userInfoService.getMyPost(postId, userId));
     }
 
-    // 나의 게시글 목록 조회 (공개 및 비공개 포함)
     @Operation(
             summary = "나의 게시글 목록 조회",
             description = """
@@ -93,22 +88,66 @@ public class UserInfoController {
             security = @SecurityRequirement(name = "JWT")
     )
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "조회 성공",
-                    content = @Content(schema = @Schema(implementation = SuccessResponse.class))),
-            @ApiResponse(responseCode = "401", description = "인증 실패", // authenticated()이므로 인증 필요
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            @ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(schema = @Schema(implementation = SuccessResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @GetMapping("/me/posts")
     public SuccessResponse<UserPostsResponseDTO> getMyAllPosts(
             @Parameter(hidden = true) @AuthenticationPrincipal UUID userId,
             @RequestParam(required = false) Long categoryId,
-            @ParameterObject
-            @PageableDefault(size = 6, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
-    ) {
+            @ParameterObject @PageableDefault(size = 6, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+
         UserPostsResponseDTO responseDTO = userInfoService.getMyAllPosts(userId, categoryId, pageable);
         return SuccessResponse.of(responseDTO);
     }
 
+    @Operation(summary = "내가 작성한 게시글 중 다른 사람이 댓글을 단 게시글 목록 조회", description = "현재 인증된 사용자가 작성한 게시글 중 하나라도 댓글이 달린 게시글을 조회합니다.", security = @SecurityRequirement(name = "JWT"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(schema = @Schema(implementation = SuccessResponse.class)))
+    })
+    @GetMapping("/me/posts/comments")
+    public SuccessResponse<Page<BlogPostSummaryDTO>> getMyPostsWithComments(
+            @Parameter(hidden = true) @AuthenticationPrincipal UUID userId,
+            @ParameterObject @PageableDefault(size = 6, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+
+        return SuccessResponse.of(blogPostService.getMyPostsWithComments(userId, pageable));
+    }
+
+    @Operation(summary = "내가 좋아요 누른 게시글 목록 조회", description = "내가 좋아요를 누른 게시글 목록을 페이지 단위로 조회합니다.", security = @SecurityRequirement(name = "JWT"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "좋아요한 게시글 목록 조회 성공", content = @Content(schema = @Schema(implementation = SuccessResponse.class)))
+    })
+    @GetMapping("/me/likes/posts")
+    public SuccessResponse<Page<BlogPostSummaryDTO>> getLikedPosts(
+            @Parameter(hidden = true) @AuthenticationPrincipal UUID userId,
+            @ParameterObject @PageableDefault(size = 6, sort = "post.createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+
+        return SuccessResponse.of(blogPostService.getLikedPosts(userId, pageable));
+    }
+
+    @Operation(summary = "내가 댓글 단 게시글 목록 조회", description = "내가 댓글 단 게시글 목록을 페이지 단위로 조회합니다.", security = @SecurityRequirement(name = "JWT"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "댓글 단 게시글 목록 조회 성공", content = @Content(schema = @Schema(implementation = SuccessResponse.class)))
+    })
+    @GetMapping("/me/comments/posts")
+    public SuccessResponse<Page<BlogPostSummaryDTO>> getMyCommentedPosts(
+            @Parameter(hidden = true) @AuthenticationPrincipal UUID userId,
+            @ParameterObject @PageableDefault(size = 6, sort = "post.createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+
+        return SuccessResponse.of(blogPostService.getMyCommentedPosts(userId, pageable));
+    }
+
+    @Operation(summary = "내가 쓴 댓글 목록 조회", description = "현재 인증된 사용자가 작성한 댓글 목록을 페이지 단위로 최근에 작성한 순으로 조회합니다.", security = @SecurityRequirement(name = "JWT"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(schema = @Schema(implementation = SuccessResponse.class))),
+            @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @GetMapping("/me/comments")
+    public SuccessResponse<Page<CommentResponseDTO>> getMyComments(
+            @Parameter(hidden = true) @AuthenticationPrincipal UUID userId,
+            @ParameterObject @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+
+        return SuccessResponse.of(commentService.getMyComments(userId, pageable));
+    }
 }

--- a/src/main/java/Bubble/bubblog/domain/user/entity/User.java
+++ b/src/main/java/Bubble/bubblog/domain/user/entity/User.java
@@ -6,7 +6,9 @@ import Bubble.bubblog.domain.post.entity.BlogPost;
 import Bubble.bubblog.domain.post.entity.PostLike;
 import Bubble.bubblog.domain.user.dto.req.SignupRequestDTO;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.GenericGenerator;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -19,6 +21,7 @@ import java.util.UUID;
 @Getter
 @Entity     // 현재 클래스가 JPA 엔티티임을 선언 -> 이 클래스를 기반으로 DB 테이블을 생성 및 조작 가능. JPA가 이 클래스를 보고 users 테이블과 매핑
 @Table(name = "users")   // 해당 엔티티가 매핑될 테이블 명 users
+@NoArgsConstructor(access = AccessLevel.PROTECTED)  // 기본 생성자 protected 접근 제어
 public class User {
 
     @Id     // primary key임을 나타내는 어노테이션
@@ -56,7 +59,7 @@ public class User {
     @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
     private List<Persona> persona = new ArrayList<>();
 
-    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
     private List<PostLike> likes = new ArrayList<>();
 
 

--- a/src/main/java/Bubble/bubblog/domain/user/entity/User.java
+++ b/src/main/java/Bubble/bubblog/domain/user/entity/User.java
@@ -2,6 +2,7 @@ package Bubble.bubblog.domain.user.entity;
 
 import Bubble.bubblog.domain.category.entity.Category;
 import Bubble.bubblog.domain.chatbot.entity.Persona;
+import Bubble.bubblog.domain.comment.entity.Comment;
 import Bubble.bubblog.domain.post.entity.BlogPost;
 import Bubble.bubblog.domain.post.entity.PostLike;
 import Bubble.bubblog.domain.user.dto.req.SignupRequestDTO;
@@ -62,8 +63,8 @@ public class User {
     @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
     private List<PostLike> likes = new ArrayList<>();
 
-
-
+    @OneToMany(mappedBy = "blogPost", fetch = FetchType.LAZY)  // Soft delete 이므로 CASCADE 설정 X
+    private List<Comment> comments;
 
     // 프로필 이미지 설정하고 user 생성
     private static User of(String email, String password, String nickname, String profileImageUrl) {
@@ -97,6 +98,5 @@ public class User {
     public void updateProfileImageUrl(String profileImageUrl) {
         this.profileImageUrl = profileImageUrl;
     }
-
 
 }

--- a/src/main/java/Bubble/bubblog/domain/user/entity/User.java
+++ b/src/main/java/Bubble/bubblog/domain/user/entity/User.java
@@ -63,7 +63,7 @@ public class User {
     @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
     private List<PostLike> likes = new ArrayList<>();
 
-    @OneToMany(mappedBy = "blogPost", fetch = FetchType.LAZY)  // Soft delete 이므로 CASCADE 설정 X
+    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)  // Soft delete 이므로 CASCADE 설정 X
     private List<Comment> comments;
 
     // 프로필 이미지 설정하고 user 생성

--- a/src/main/java/Bubble/bubblog/domain/user/service/UserAuthService.java
+++ b/src/main/java/Bubble/bubblog/domain/user/service/UserAuthService.java
@@ -1,0 +1,17 @@
+package Bubble.bubblog.domain.user.service;
+
+import Bubble.bubblog.domain.user.dto.authRes.TokensDTO;
+import Bubble.bubblog.domain.user.dto.req.LoginRequestDTO;
+import Bubble.bubblog.domain.user.dto.req.SignupRequestDTO;
+import Bubble.bubblog.domain.user.entity.User;
+
+import java.util.UUID;
+
+public interface UserAuthService {
+    // 사용자 인증 서비스
+    void signup(SignupRequestDTO request);
+    User login(LoginRequestDTO request);
+    void logout(UUID userId);
+    TokensDTO reissueTokens(String refreshToken);
+    TokensDTO issueTokens(UUID userId);
+}

--- a/src/main/java/Bubble/bubblog/domain/user/service/UserInfoService.java
+++ b/src/main/java/Bubble/bubblog/domain/user/service/UserInfoService.java
@@ -1,0 +1,17 @@
+package Bubble.bubblog.domain.user.service;
+
+import Bubble.bubblog.domain.post.dto.res.BlogPostDetailDTO;
+import Bubble.bubblog.domain.post.dto.res.UserPostsResponseDTO;
+import Bubble.bubblog.domain.user.dto.infoRes.UserInfoDTO;
+import Bubble.bubblog.domain.user.dto.req.UserUpdateDTO;
+import org.springframework.data.domain.Pageable;
+
+import java.util.UUID;
+
+public interface UserInfoService {
+    // 사용자 정보 서비스
+    UserInfoDTO getUserInfo(UUID userId);
+    void updateUser(UUID userId, UserUpdateDTO request);
+    BlogPostDetailDTO getMyPost(Long postId, UUID userId);
+    UserPostsResponseDTO getMyAllPosts(UUID userId, Long categoryId, Pageable pageable);
+}

--- a/src/main/java/Bubble/bubblog/domain/user/service/UserInfoServiceImpl.java
+++ b/src/main/java/Bubble/bubblog/domain/user/service/UserInfoServiceImpl.java
@@ -22,6 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -71,7 +72,7 @@ public class UserInfoServiceImpl implements UserInfoService {
     @Override
     @Transactional(readOnly = true)
     public BlogPostDetailDTO getMyPost(Long postId, UUID userId) {
-       BlogPost post = blogPostRepository.findById(postId)
+       BlogPost post = blogPostRepository.findDetailById(postId)
                 .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
 
         // 로그인한 사용자가 게시글의 소유자인지 확인
@@ -84,7 +85,13 @@ public class UserInfoServiceImpl implements UserInfoService {
 
         // 소유자라면 공개/비공개 여부와 상관없이 접근 허용
         List<String> categoryList = categoryClosureRepository.findAncestorNamesByDescendantId(post.getCategory().getId());
-        return new BlogPostDetailDTO(post, categoryList);
+
+        List<String> tags = post.getPostTags().stream()
+                .map(postTag -> postTag.getTag().getName())
+                .collect(Collectors.toList());
+
+
+        return new BlogPostDetailDTO(post, categoryList, tags);
     }
 
     // 나의 게시글 목록 조회 (공개 및 비공개 포함)

--- a/src/main/java/Bubble/bubblog/domain/user/service/UserInfoServiceImpl.java
+++ b/src/main/java/Bubble/bubblog/domain/user/service/UserInfoServiceImpl.java
@@ -1,0 +1,115 @@
+package Bubble.bubblog.domain.user.service;
+
+import Bubble.bubblog.domain.category.repository.CategoryClosureRepository;
+import Bubble.bubblog.domain.category.repository.CategoryRepository;
+import Bubble.bubblog.domain.post.dto.res.BlogPostDetailDTO;
+import Bubble.bubblog.domain.post.dto.res.BlogPostSummaryDTO;
+import Bubble.bubblog.domain.post.dto.res.UserPostsResponseDTO;
+import Bubble.bubblog.domain.post.entity.BlogPost;
+import Bubble.bubblog.domain.post.repository.BlogPostRepository;
+import Bubble.bubblog.domain.post.repository.PostLikeRepository;
+import Bubble.bubblog.domain.user.dto.infoRes.UserInfoDTO;
+import Bubble.bubblog.domain.user.dto.req.UserUpdateDTO;
+import Bubble.bubblog.domain.user.entity.User;
+import Bubble.bubblog.domain.user.repository.UserRepository;
+import Bubble.bubblog.global.exception.CustomException;
+import Bubble.bubblog.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class UserInfoServiceImpl implements UserInfoService {
+
+    private final UserRepository userRepository;
+    private final BlogPostRepository blogPostRepository;
+    private final CategoryClosureRepository categoryClosureRepository;
+    private final CategoryRepository categoryRepository;
+    private final PostLikeRepository postLikeRepository;
+
+    // user 정보 조회
+    @Override
+    @Transactional(readOnly = true)
+    public UserInfoDTO getUserInfo(UUID userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        return new UserInfoDTO(
+                user.getId(),
+                user.getNickname(),
+                user.getProfileImageUrl()
+        );
+    }
+
+    // user 정보 수정
+    @Override
+    @Transactional
+    public void updateUser(UUID userId, UserUpdateDTO request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        // 닉네임 수정
+        String newNickname = request.getNickname();
+        if (newNickname != null && !newNickname.equals(user.getNickname())) {
+            if (userRepository.existsByNickname(newNickname)) {
+                throw new CustomException(ErrorCode.DUPLICATE_NICKNAME);
+            }
+            user.updateNickname(newNickname);
+        }
+
+        // 프로필 이미지 수정 (null이면 이미지 제거)
+        user.updateProfileImageUrl(request.getProfileImageUrl());
+    }
+
+    // 나의 게시글 상세 조회 (공개 및 비공개 포함)
+    @Override
+    @Transactional(readOnly = true)
+    public BlogPostDetailDTO getMyPost(Long postId, UUID userId) {
+       BlogPost post = blogPostRepository.findById(postId)
+                .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
+
+        // 로그인한 사용자가 게시글의 소유자인지 확인
+        boolean isOwner = post.getUser().getId().equals(userId);
+
+        if (!isOwner) {
+            // 로그인했지만, 자신의 게시글이 아니라면 접근 거부 (비공개든 공개든 상관없이)
+            throw new CustomException(ErrorCode.UNAUTHORIZED_POST_ACCESS);
+        }
+
+        // 소유자라면 공개/비공개 여부와 상관없이 접근 허용
+        List<String> categoryList = categoryClosureRepository.findAncestorNamesByDescendantId(post.getCategory().getId());
+        return new BlogPostDetailDTO(post, categoryList);
+    }
+
+    // 나의 게시글 목록 조회 (공개 및 비공개 포함)
+    @Override
+    @Transactional(readOnly = true)
+    public UserPostsResponseDTO getMyAllPosts(UUID userId, Long categoryId, Pageable pageable) {
+        List<Long> categoryIds = null;
+        if (categoryId != null) {
+            if (!categoryRepository.existsById(categoryId)) {
+                throw new CustomException(ErrorCode.CATEGORY_NOT_FOUND);
+            }
+            categoryIds = categoryClosureRepository.findAllSubtreeIdsIncludingSelf(categoryId);
+        }
+
+        Page<BlogPost> posts = blogPostRepository
+                .searchUserPosts(userId, true, categoryIds, pageable);   // isOwner을 false로 고정 -> 공개 게시글만 조회하니까
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        return new UserPostsResponseDTO(
+                user.getId(),
+                user.getNickname(),
+                posts.map(BlogPostSummaryDTO::new).getContent()
+        );
+    }
+
+}

--- a/src/main/java/Bubble/bubblog/global/config/SecurityConfig.java
+++ b/src/main/java/Bubble/bubblog/global/config/SecurityConfig.java
@@ -6,6 +6,7 @@ import Bubble.bubblog.global.util.jwt.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -39,14 +40,17 @@ public class SecurityConfig {
                                         "/api/v3/api-docs.yaml"
                                 ).permitAll()
                                 // 로그인, 회원가입, 비밀번호 재설정 같은 엔드포인트 허용
-                                .requestMatchers(
-                                        "/api/auth/login",
-                                        "/api/auth/signup",
-                                        "/api/auth/reissue"
-                                ).permitAll()
+                                .requestMatchers("/api/auth/login", "/api/auth/signup", "/api/auth/reissue").permitAll()
+                                // 게시글 조회 관련 API 허용
+                                .requestMatchers(HttpMethod.GET, "/api/posts/**").permitAll()
+                                // 조회수 증가 API 허용
+                                .requestMatchers(HttpMethod.PUT, "/api/posts/*/view").permitAll()
+                                // 말투 조회 관련 API 허용
+                                .requestMatchers(HttpMethod.GET, "/api/personas/**").permitAll()
+                                // 사용자 정보 조회 관련 API 허용
+                                .requestMatchers(HttpMethod.GET, "/api/users/{userId}").permitAll()
                         // 그 외 요청은 인증 필요
                         .anyRequest().authenticated()
-
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .exceptionHandling(ex -> ex
@@ -58,6 +62,6 @@ public class SecurityConfig {
 
     @Bean
     public PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder(); // ✅ 여기다 넣어도 OK
+        return new BCryptPasswordEncoder();
     }
 }

--- a/src/main/java/Bubble/bubblog/global/config/SecurityConfig.java
+++ b/src/main/java/Bubble/bubblog/global/config/SecurityConfig.java
@@ -37,11 +37,12 @@ public class SecurityConfig {
                                         "/api/swagger-ui/**",
                                         "/api/swagger-resources/**",
                                         "/api/v3/api-docs/**",
-                                        "/api/v3/api-docs.yaml"
+                                        "/api/v3/api-docs.yaml",
+                                        "/swagger-ui.html"
                                 ).permitAll()
                                 // 로그인, 회원가입, 비밀번호 재설정 같은 엔드포인트 허용
                                 .requestMatchers("/api/auth/login", "/api/auth/signup", "/api/auth/reissue").permitAll()
-                                // 게시글 조회 관련 API 허용
+                                // 게시글 조회 관련 API 허용 (특정 게시글의 전체 댓글 조회도 여기에 포함)
                                 .requestMatchers(HttpMethod.GET, "/api/posts/**").permitAll()
                                 // 조회수 증가 API 허용
                                 .requestMatchers(HttpMethod.PUT, "/api/posts/*/view").permitAll()
@@ -49,6 +50,8 @@ public class SecurityConfig {
                                 .requestMatchers(HttpMethod.GET, "/api/personas/**").permitAll()
                                 // 사용자 정보 조회 관련 API 허용
                                 .requestMatchers(HttpMethod.GET, "/api/users/{userId}").permitAll()
+                                // 댓글 조회 관련 API 허용
+                                .requestMatchers(HttpMethod.GET, "/api/comments/**").permitAll()
                         // 그 외 요청은 인증 필요
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/Bubble/bubblog/global/exception/ErrorCode.java
+++ b/src/main/java/Bubble/bubblog/global/exception/ErrorCode.java
@@ -34,7 +34,11 @@ public enum ErrorCode {
 
     // 페르소나
     PERSONA_NOT_FOUND(404, "말투를 찾을 수 없습니다."),
-    UNAUTHORIZED_PERSONA_ACCESS(403, "해당 말투에 대한 권한이 없습니다.");
+    UNAUTHORIZED_PERSONA_ACCESS(403, "해당 말투에 대한 권한이 없습니다."),
+
+    // 태그
+    DUPLICATE_TAG(400, "태그명이 중복입니다."),
+    TAG_NOT_FOUND(404, "존재하지 않는 태그입니다.");
 
     // S3
 

--- a/src/main/java/Bubble/bubblog/global/exception/ErrorCode.java
+++ b/src/main/java/Bubble/bubblog/global/exception/ErrorCode.java
@@ -38,7 +38,18 @@ public enum ErrorCode {
 
     // 태그
     DUPLICATE_TAG(400, "태그명이 중복입니다."),
-    TAG_NOT_FOUND(404, "존재하지 않는 태그입니다.");
+    TAG_NOT_FOUND(404, "존재하지 않는 태그입니다."),
+
+    // 댓글
+    COMMENT_NOT_FOUND(404, "해당 댓글을 찾을 수 없습니다."),
+    PARENT_COMMENT_NOT_FOUND(404, "부모 댓글을 찾을 수 없습니다."),
+    INVALID_PARENT_FOR_POST(400, "해당 부모는 다른 게시글의 댓글입니다."),
+    REPLY_TO_REPLY_NOT_ALLOWED(400, "대댓글에 대해 댓글을 작성할 수 없습니다."),
+    REPLY_TO_DELETED_COMMENT_NOT_ALLOWED(400, "삭제된 댓글에 댓글을 작성할 수 없습니다."),
+    NO_PERMISSION_TO_EDIT_COMMENT(403, "해당 댓글을 수정할 권한이 없습니다."),
+    NO_PERMISSION_TO_DELETE_COMMENT(403, "해당 댓글을 삭제할 권한이 없습니다."),
+    NOT_ROOT_COMMENT(400, "자식 댓글의 스레드를 조회할 수 없습니다. 루트 댓글의 스레드를 조회해주세요."),
+    CANNOT_LIKE_DELETED_COMMENT(400, "삭제된 댓글에 좋아요를 누를 수 없습니다.");
 
     // S3
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,3 +13,10 @@ springdoc:
     path: /api/v3/api-docs
   swagger-ui:
     path: /api/swagger-ui.html
+
+logging:
+  level:
+    root: DEBUG
+    org.springframework: DEBUG
+    org.hibernate.SQL: DEBUG
+

--- a/src/test/java/Bubble/bubblog/domain/post/service/BlogPostServiceTest.java
+++ b/src/test/java/Bubble/bubblog/domain/post/service/BlogPostServiceTest.java
@@ -1,0 +1,84 @@
+package Bubble.bubblog.domain.post.service;
+
+import Bubble.bubblog.domain.category.entity.Category;
+import Bubble.bubblog.domain.category.repository.CategoryRepository;
+import Bubble.bubblog.domain.post.dto.req.BlogPostRequestDTO;
+import Bubble.bubblog.domain.post.dto.res.BlogPostDetailDTO;
+import Bubble.bubblog.domain.post.repository.BlogPostRepository;
+import Bubble.bubblog.domain.tag.repository.PostTagRepository;
+import Bubble.bubblog.domain.tag.repository.TagRepository;
+import Bubble.bubblog.domain.user.dto.req.SignupRequestDTO;
+import Bubble.bubblog.domain.user.entity.User;
+import Bubble.bubblog.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@SpringBootTest
+@Transactional   // 테스트 종료 후 자동 롤백
+@DisplayName("BlogPostService 통합 테스트")
+class BlogPostServiceTest {
+    // 의존성 주입
+    @Autowired private BlogPostService blogPostService;
+    @Autowired private UserRepository userRepository;
+    @Autowired private BlogPostRepository blogPostRepository;
+    @Autowired private CategoryRepository categoryRepository;
+    @Autowired private TagRepository tagRepository;
+    @Autowired private PostTagRepository postTagRepository;
+    @Autowired private PasswordEncoder passwordEncoder;
+
+    @Test
+    @DisplayName("게시글 생성 시 태그도 함께 생성된다")
+    public void createPost() {
+        // given
+        SignupRequestDTO signupDTO = new SignupRequestDTO();
+        signupDTO.setEmail("test@bubblog.com");
+        signupDTO.setPassword("password123!");
+        signupDTO.setNickname("tester");
+
+        User user = userRepository.save(User.from(signupDTO, passwordEncoder));
+        Category category = categoryRepository.save(Category.of("테스트 카테고리", user));
+
+        BlogPostRequestDTO request = BlogPostRequestDTO.builder()
+                .title("제목")
+                .content("내용")
+                .summary("요약")
+                .publicVisible(true)
+                .thumbnailUrl("thumbnail.jpg")
+                .categoryId(category.getId())
+                .tags(List.of("Java", "Spring"))
+                .build();
+
+        // when
+        BlogPostDetailDTO result = blogPostService.createPost(request, user.getId());
+
+        // then
+        Assertions.assertEquals("제목", result.getTitle());
+        Assertions.assertTrue(result.getTags().containsAll(List.of("Java", "Spring")));
+        Assertions.assertEquals(2, tagRepository.findAll().size());
+        Assertions.assertEquals(2, postTagRepository.findAll().size());
+    }
+
+    @Test
+    public void getPost_withTag() {
+    }
+
+
+    @Test
+    void getPostsByTagName() {
+    }
+
+    @Test
+    void deletePost() {
+    }
+
+    @Test
+    void updatePost() {
+    }
+}


### PR DESCRIPTION
- 게시글 상세 DTO에 tag 리스트 추가
- 게시글 생성/수정 시 Request에 tag 리스트 추가해서 보내도록 서비스 코드 작성
- 태그 ID 기반 게시글 목록 조회 API
- 게시글 수정할 때 무조건 기존 태그-게시글 관계 제거하고, PUT 으로 새로 받은 태그 리스트를 관계로 저장
- tag 목록 조회 / 특정 tag 조회 API
- blogService 관련 통합테스트 -> 게시글 생성 메소드만 테스트 진행함
- Swagger 테스트로는 이상 없음 
- 코드 리뷰 부탁드립니다.

게시글 생성 응답 예시
<img width="871" height="514" alt="게시글 생성 응답" src="https://github.com/user-attachments/assets/60e317d2-c6d3-4e7d-a994-35c6ac4f6a55" />
