### PR TITLE
[fix(BE)] : 특정 사용자의 게시글 목록 조회 시 응답 구조가 페이지네이션이 적용되지 않고 반환되는 문제 해결

### DIFF
--- a/src/main/java/Bubble/bubblog/domain/post/dto/res/UserPostsResponseDTO.java
+++ b/src/main/java/Bubble/bubblog/domain/post/dto/res/UserPostsResponseDTO.java
@@ -1,15 +1,16 @@
 package Bubble.bubblog.domain.post.dto.res;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-
 import java.util.List;
 import java.util.UUID;
 
-@Getter
-@AllArgsConstructor
-public class UserPostsResponseDTO {
-    private UUID userId;
-    private String nickname;
-    private List<BlogPostSummaryDTO> posts;
-}
+public record UserPostsResponseDTO(
+        UUID userId,
+        String nickname,
+        List<BlogPostSummaryDTO> posts,
+        int page,
+        int size,
+        long totalElements,
+        int totalPages,
+        boolean hasNext
+) {}
+

--- a/src/main/java/Bubble/bubblog/domain/post/service/BlogPostServiceImpl.java
+++ b/src/main/java/Bubble/bubblog/domain/post/service/BlogPostServiceImpl.java
@@ -139,7 +139,12 @@ public class BlogPostServiceImpl implements BlogPostService {
         return new UserPostsResponseDTO(
                 user.getId(),
                 user.getNickname(),
-                posts.map(BlogPostSummaryDTO::new).getContent()
+                posts.map(BlogPostSummaryDTO::new).getContent(),
+                posts.getNumber(),
+                posts.getSize(),
+                posts.getTotalElements(),
+                posts.getTotalPages(),
+                posts.hasNext()
         );
     }
 

--- a/src/main/java/Bubble/bubblog/domain/user/service/UserInfoServiceImpl.java
+++ b/src/main/java/Bubble/bubblog/domain/user/service/UserInfoServiceImpl.java
@@ -115,7 +115,12 @@ public class UserInfoServiceImpl implements UserInfoService {
         return new UserPostsResponseDTO(
                 user.getId(),
                 user.getNickname(),
-                posts.map(BlogPostSummaryDTO::new).getContent()
+                posts.map(BlogPostSummaryDTO::new).getContent(),
+                posts.getNumber(),
+                posts.getSize(),
+                posts.getTotalElements(),
+                posts.getTotalPages(),
+                posts.hasNext()
         );
     }
 


### PR DESCRIPTION
## 요약
- 특정 사용자(userId에 따른)의 게시글 목록 조회 시 페이지네이션이 적용되지 않은 현상 발생
- 기존 응답 데이터로 사용한 DTO에 page 관련 필드를 추가하여 해결

## Changes
아래 엔드포인트와 관련된 서비스 코드 수정
- GET /api/posts/users/userId
- GET /api/users/me/posts